### PR TITLE
Fix Private DNS detection, missing reconnect notifications, and a foreground service memory leak

### DIFF
--- a/app/src/main/java/com/vinnovateit/latch/domain/model/SessionRepository.kt
+++ b/app/src/main/java/com/vinnovateit/latch/domain/model/SessionRepository.kt
@@ -24,6 +24,12 @@ import java.util.Calendar
 import kotlin.random.Random
 
 object SessionRepository {
+  // Bounds the in-memory per-point history kept for the live speed graph. At the ~2s poll
+  // interval used by TrafficStatsLogger this is roughly an hour of history; session-end totals
+  // (rx/tx bytes, max speeds) are tracked separately in LiveConnectionStatus and are NOT affected
+  // by this cap.
+  private const val MAX_LIVE_HISTORY_POINTS = 1800
+
   private var applicationContext: Application? = null
   private lateinit var statsDao: StatsDao
   private val repoScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
@@ -103,7 +109,11 @@ object SessionRepository {
               dataUsage
             )
           val updatedStatus = currentStatus.copy(
-            liveData = currentStatus.liveData + newPoint
+            liveData = (currentStatus.liveData + newPoint).takeLast(MAX_LIVE_HISTORY_POINTS),
+            totalRxBytes = currentStatus.totalRxBytes + dataUsage.rxBytes,
+            totalTxBytes = currentStatus.totalTxBytes + dataUsage.txBytes,
+            maxRxBps = maxOf(currentStatus.maxRxBps, dataUsage.rxBps),
+            maxTxBps = maxOf(currentStatus.maxTxBps, dataUsage.txBps)
           )
           _liveStatus.value = updatedStatus
         }
@@ -126,11 +136,11 @@ object SessionRepository {
     connectivityManager.bindProcessToNetwork(null)
     _liveStatus.value = null
 
-    val totalRxBytes = sessionToFinalize.liveData.sumOf { it.usage.rxBytes }
-    val totalTxBytes = sessionToFinalize.liveData.sumOf { it.usage.txBytes }
+    val totalRxBytes = sessionToFinalize.totalRxBytes
+    val totalTxBytes = sessionToFinalize.totalTxBytes
     val totalDataUsed = totalRxBytes + totalTxBytes
-    val maxRxBps = sessionToFinalize.liveData.maxOfOrNull { it.usage.rxBps } ?: 0L
-    val maxTxBps = sessionToFinalize.liveData.maxOfOrNull { it.usage.txBps } ?: 0L
+    val maxRxBps = sessionToFinalize.maxRxBps
+    val maxTxBps = sessionToFinalize.maxTxBps
 
     if (totalDataUsed < 1024) {
       triggerWidgetUpdate()

--- a/app/src/main/java/com/vinnovateit/latch/domain/model/WifiStatsManager.kt
+++ b/app/src/main/java/com/vinnovateit/latch/domain/model/WifiStatsManager.kt
@@ -7,7 +7,17 @@ data class DataUsage(
   val txBps: Long = txBytes
 )
 data class LiveDataPoint(val timestamp: Long, val usage: DataUsage)
-data class LiveConnectionStatus(val startTimeMillis: Long, val liveData: List<LiveDataPoint>)
+data class LiveConnectionStatus(
+  val startTimeMillis: Long,
+  val liveData: List<LiveDataPoint>,
+  // Running totals across the whole session, tracked independently of `liveData` since that
+  // list is capped to a trailing window (see SessionRepository.MAX_LIVE_HISTORY_POINTS) and can
+  // no longer be summed/maxed directly once older points have been dropped.
+  val totalRxBytes: Long = 0,
+  val totalTxBytes: Long = 0,
+  val maxRxBps: Long = 0,
+  val maxTxBps: Long = 0
+)
 data class SessionSummary(
   val startTimestamp: Long,
   val endTimestamp: Long,

--- a/app/src/main/java/com/vinnovateit/latch/features/home/components/SpectrumCard.kt
+++ b/app/src/main/java/com/vinnovateit/latch/features/home/components/SpectrumCard.kt
@@ -194,7 +194,7 @@ private fun StatusIndicator(connectionStatus: ConnectionStatus) {
                   modifier = Modifier.size(64.dp)
                 )
                 is ConnectionStatus.Failed -> {
-                    val isUnsupported = status.message.equals(stringResource(R.string.status_unsupported_network), ignoreCase = true)
+                    val isUnsupported = status.message.contains(stringResource(R.string.status_unsupported_network), ignoreCase = true)
                     Icon(
                       imageVector = if (isUnsupported) Icons.Rounded.QuestionMark else Icons.Rounded.Error,
                       contentDescription = stringResource(R.string.status_login_failed),

--- a/app/src/main/java/com/vinnovateit/latch/features/stats/StatsViewModel.kt
+++ b/app/src/main/java/com/vinnovateit/latch/features/stats/StatsViewModel.kt
@@ -35,12 +35,10 @@ class StatsViewModel(application: Application) : AndroidViewModel(application) {
         SessionSummary(
           startTimestamp = it.startTimeMillis,
           endTimestamp = System.currentTimeMillis(), // It's ongoing
-          totalData = DataUsage(
-            it.liveData.sumOf { p -> p.usage.rxBytes },
-            it.liveData.sumOf { p -> p.usage.txBytes }),
+          totalData = DataUsage(it.totalRxBytes, it.totalTxBytes),
           history = it.liveData,
-          maxRxBps = it.liveData.maxOfOrNull { p -> p.usage.rxBytes } ?: 0L,
-          maxTxBps = it.liveData.maxOfOrNull { p -> p.usage.txBytes } ?: 0L
+          maxRxBps = it.maxRxBps,
+          maxTxBps = it.maxTxBps
         )
       } ?: last // If not live, show the last completed session
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
@@ -54,12 +52,10 @@ class StatsViewModel(application: Application) : AndroidViewModel(application) {
         val liveSummary = SessionSummary(
           startTimestamp = it.startTimeMillis,
           endTimestamp = System.currentTimeMillis(),
-          totalData = DataUsage(
-            it.liveData.sumOf { p -> p.usage.rxBytes },
-            it.liveData.sumOf { p -> p.usage.txBytes }),
+          totalData = DataUsage(it.totalRxBytes, it.totalTxBytes),
           history = it.liveData,
-          maxRxBps = it.liveData.maxOfOrNull { p -> p.usage.rxBytes } ?: 0L,
-          maxTxBps = it.liveData.maxOfOrNull { p -> p.usage.txBytes } ?: 0L
+          maxRxBps = it.maxRxBps,
+          maxTxBps = it.maxTxBps
         )
         val historyWithoutLive = history.filter { it.startTimestamp != liveSummary.startTimestamp }
         mergeSessions(listOf(liveSummary) + historyWithoutLive, 60_000L)

--- a/app/src/main/java/com/vinnovateit/latch/features/wifi/background/ForegroundService.kt
+++ b/app/src/main/java/com/vinnovateit/latch/features/wifi/background/ForegroundService.kt
@@ -9,6 +9,7 @@ import android.net.NetworkCapabilities
 import android.net.NetworkRequest
 import android.os.Build
 import android.os.IBinder
+import android.provider.Settings
 import android.util.Log
 import androidx.core.app.NotificationCompat
 import com.vinnovateit.latch.R
@@ -21,6 +22,7 @@ import com.vinnovateit.latch.features.wifi.manager.AutoLoginManager
 import com.vinnovateit.latch.features.wifi.manager.ConnectionStatus
 import com.vinnovateit.latch.features.wifi.manager.ConnectionStatusManager
 import com.vinnovateit.latch.features.wifi.manager.LoginResult
+import com.vinnovateit.latch.features.wifi.manager.UiNotifier
 import kotlinx.coroutines.*
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -35,6 +37,7 @@ class ForegroundService : Service() {
     private val channelId = "WIFI_LOGIN_CHANNEL"
 
     private var currentWifiNetwork: Network? = null
+    private var networkCallback: ConnectivityManager.NetworkCallback? = null
 
     private var isNotificationHidden = false
     private var notificationUpdateJob: Job? = null
@@ -134,6 +137,14 @@ class ForegroundService : Service() {
         super.onDestroy()
         Log.d("ForegroundService", "Service destroyed")
         stopForeground(STOP_FOREGROUND_REMOVE)
+        networkCallback?.let {
+            try {
+                connectivityManager.unregisterNetworkCallback(it)
+            } catch (e: Exception) {
+                Log.e("ForegroundService", "Failed to unregister network callback", e)
+            }
+        }
+        networkCallback = null
         serviceScope.cancel()
     }
 
@@ -206,7 +217,13 @@ class ForegroundService : Service() {
         return if (caps?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true) activeNetwork else null
     }
 
-    private fun checkNetworkAndAct(network: Network, isRevalidating: Boolean, retryCount: Int = 0, isSilent: Boolean = false) {
+    private fun checkNetworkAndAct(
+        network: Network,
+        isRevalidating: Boolean,
+        retryCount: Int = 0,
+        isSilent: Boolean = false,
+        notifyOnReconnect: Boolean = false
+    ) {
         serviceScope.launch(Dispatchers.IO) {
             ConnectionStatusManager.postStatus(
                 ConnectionStatus.Companion.Connecting(getString(R.string.status_checking_internet))
@@ -224,6 +241,10 @@ class ForegroundService : Service() {
                 val timeString = timeFormat.format(Date())
                 updateNotification("Latched", "Connected at $timeString")
 
+                if (notifyOnReconnect) {
+                    UiNotifier.showToast(applicationContext, "Reconnected to VIT WiFi at $timeString")
+                }
+
                 startHealthCheck(network)
                 startNotificationUpdates()
                 return@launch
@@ -231,12 +252,24 @@ class ForegroundService : Service() {
 
             // --- IF INTERNET IS NOT 204 YET ---
 
+            if (internetStatus == CaptivePortalDetector.DNS_RESOLUTION_FAILED && !isRevalidating) {
+                Log.w("ForegroundService", "Connectivity probe failed to resolve host.")
+                val message = if (isPrivateDnsActive()) {
+                    getString(R.string.status_private_dns_blocking)
+                } else {
+                    getString(R.string.status_unsupported_network)
+                }
+                ConnectionStatusManager.postStatus(ConnectionStatus.Failed(message))
+                stopSelf()
+                return@launch
+            }
+
             // FIX #2: If we just logged in, give the portal 2 seconds to open the gates instead of infinite looping.
             if (isRevalidating) {
                 if (retryCount < 3) {
                     Log.d("ForegroundService", "Waiting for network gates to open... (Attempt ${retryCount + 1})")
                     delay(2000) // Wait 2 seconds
-                    checkNetworkAndAct(network, true, retryCount + 1, isSilent)
+                    checkNetworkAndAct(network, true, retryCount + 1, isSilent, notifyOnReconnect)
                 } else {
                     Log.w("ForegroundService", "Network never granted internet after successful login.")
                     ConnectionStatusManager.postStatus(ConnectionStatus.Failed("Network timeout after login"))
@@ -252,11 +285,11 @@ class ForegroundService : Service() {
             }
 
             Log.d("ForegroundService", "Captive portal detected. Proceeding to login.")
-            handleCaptivePortal(network)
+            handleCaptivePortal(network, notifyOnReconnect)
         }
     }
 
-    private fun handleCaptivePortal(network: Network) {
+    private fun handleCaptivePortal(network: Network, notifyOnReconnect: Boolean = false) {
         serviceScope.launch(Dispatchers.IO) {
             ConnectionStatusManager.postStatus(
                 ConnectionStatus.Companion.Connecting(getString(R.string.status_authenticating))
@@ -270,7 +303,7 @@ class ForegroundService : Service() {
                     when (AutoLoginManager.attemptLogin(user, pass, network, false, fallbackIp)) {
                         is LoginResult.Success -> {
                             Log.d("ForegroundService", "Login successful, re-validating network.")
-                            checkNetworkAndAct(network, true)
+                            checkNetworkAndAct(network, true, notifyOnReconnect = notifyOnReconnect)
                         }
                         is LoginResult.Failure -> {
                             ConnectionStatusManager.postStatus(ConnectionStatus.Failed(getString(R.string.status_login_failed)))
@@ -318,6 +351,16 @@ class ForegroundService : Service() {
         stopSelf()
     }
 
+    private fun isPrivateDnsActive(): Boolean {
+        return try {
+            val mode = Settings.Global.getString(contentResolver, "private_dns_mode")
+            mode != null && mode != "off"
+        } catch (e: Exception) {
+            Log.e("ForegroundService", "Failed to read private_dns_mode", e)
+            false
+        }
+    }
+
     private fun getGatewayIp(): String? {
         return try {
             val wifiManager = applicationContext.getSystemService(android.content.Context.WIFI_SERVICE) as android.net.wifi.WifiManager
@@ -340,7 +383,7 @@ class ForegroundService : Service() {
                 val status = CaptivePortalDetector.checkPortalStatus(applicationContext, network)
                 if (status != 204) {
                     Log.w("ForegroundService", "Health check failed (status: $status). Session may have expired. Triggering re-login.")
-                    checkNetworkAndAct(network, false)
+                    checkNetworkAndAct(network, false, notifyOnReconnect = true)
                 } else {
                     Log.d("ForegroundService", "Health check passed.")
                 }
@@ -361,7 +404,7 @@ class ForegroundService : Service() {
                 if (!WiFiStateDetector.isWiFiEnabled(this@ForegroundService)) {
                     return
                 }
-                checkNetworkAndAct(network, false, isSilent = !SettingsManager.autoLogin.value)
+                checkNetworkAndAct(network, false, isSilent = !SettingsManager.autoLogin.value, notifyOnReconnect = true)
             }
 
             override fun onLost(network: Network) {
@@ -375,6 +418,7 @@ class ForegroundService : Service() {
                 SessionRepository.stopSession()
             }
         }
+        this.networkCallback = networkCallback
         connectivityManager.registerNetworkCallback(request, networkCallback)
     }
 }

--- a/app/src/main/java/com/vinnovateit/latch/features/wifi/detector/CaptivePortalDetector.kt
+++ b/app/src/main/java/com/vinnovateit/latch/features/wifi/detector/CaptivePortalDetector.kt
@@ -6,8 +6,16 @@ import android.net.Network
 import android.util.Log
 import java.net.HttpURLConnection
 import java.net.URL
+import java.net.UnknownHostException
 
 object CaptivePortalDetector {
+
+    /**
+     * Sentinel returned when the connectivity probe fails specifically because the hostname
+     * could not be resolved (e.g. Android Private DNS blocking resolution on an unauthenticated
+     * captive network), as opposed to other connection failures.
+     */
+    const val DNS_RESOLUTION_FAILED = -2
 
     /**
      * Checks for a captive portal by connecting to a known endpoint.
@@ -16,7 +24,8 @@ object CaptivePortalDetector {
      * @param context Application context
      * @param network The network to check. If null, uses the active network.
      * @return The HTTP response code from the check. Returns 204 for success, other codes
-     * for a captive portal, or -1 for an exception.
+     * for a captive portal, [DNS_RESOLUTION_FAILED] if hostname resolution failed, or -1 for
+     * any other exception.
      */
     fun checkPortalStatus(context: Context, network: Network? = null): Int {
         val connectivityManager =
@@ -38,6 +47,9 @@ object CaptivePortalDetector {
             val responseCode = connection.responseCode
             connection.disconnect()
             responseCode
+        } catch (e: UnknownHostException) {
+            Log.e("CaptivePortalDetector", "Portal check failed to resolve host", e)
+            DNS_RESOLUTION_FAILED
         } catch (e: Exception) {
             Log.e("CaptivePortalDetector", "Portal check failed with exception", e)
             -1

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,6 +69,7 @@
     <string name="status_revalidating">Re-validating connection…</string>
     <string name="status_checking_network">Checking network…</string>
     <string name="status_unsupported_network">Unsupported Network</string>
+    <string name="status_private_dns_blocking">Unsupported Network — Private DNS may be blocking detection. Try disabling it in Wi-Fi settings.</string>
     <string name="status_login_failed">Login Failed</string>
     <string name="status_credentials_not_set">Credentials not set</string>
     <string name="status_disconnected_message">Disconnected</string>


### PR DESCRIPTION
## What this fixes

Closes/partially closes: #37, #38, and the notification half of #47.

**#37, Private DNS causes "Unsupported Network"**
- The connectivity probe in `CaptivePortalDetector` resolves `clients3.google.com` over the target network before login. When Private DNS is on, that lookup can fail on an unauthenticated captive network, and the failure looked exactly like any other error.
- We now catch `UnknownHostException` specifically, check if Private DNS is active, and surface a real status instead of a generic failure.
- The "Unsupported Network" string and its icon already existed in the UI, nothing was triggering it. Now it is wired up the way it was originally meant to be used.

**#47, missing notification on background reconnect (notification part only)**
- The multi device lockout described in that issue is a Pronto Networks backend session limit. There's nothing this app can do to force another device's session closed, so that part is out of scope here.
- The notification gap is fixable. When the app silently reconnects in the background, the ongoing notification just gets a quiet text update that's overwritten by speed stats within a couple seconds. There's already a proper high priority notification helper (`UiNotifier`) sitting in the codebase which is never called anywhere.
- Wired it into the two background reconnect paths (Wi-Fi coming back, and the periodic health check catching a dropped session) so the alerts come through. Manual/foreground checks are left alone since the user is already looking at the screen in that case.

**#38, foreground service holding onto RAM**
- `ForegroundService` registers a `NetworkCallback` but never keeps a reference to unregister it. Every service restart (the proactive 5h45m stop, OS kills, crashes) leaked the previous instance and everything it held. This compounds over time, which matches the "holds RAM forever" behaviour.
- Also found the live session history list grows for the entire session with no cap, full list copy on every 2 second tick, and gets fully re-walked on every graph redraw. Not a permanent leak like the one above, but real GC churn on long sessions.
- Fixed the leak by storing and unregistering the callback. Capped the history to a rolling window and moved total/max tracking to running counters so session stats stay accurate even with the cap.

## Not included

- The dead `WiFiChangeReceiver` -> `WiFiMonitor` -> `LoginTestRunner` chain is completely unreachable in production. It doesn't cause any of the reported bugs, so it is left alone. Can open a separate PR for this.

## Testing

- `./gradlew :app:compileDebugKotlin` passes cleanly, only pre-existing deprecation warnings.
- No VIT network access for me, so the actual login/Private DNS/notification behavior hasn't been verified on-device. Would appreciate a test on real hardware before merging.
