### PR TITLE
Migrate TileService.startActivityAndCollapse to the PendingIntent overload

### DIFF
--- a/app/src/main/java/com/vinnovateit/latch/features/wifi/quicksettings/LatchTileService.kt
+++ b/app/src/main/java/com/vinnovateit/latch/features/wifi/quicksettings/LatchTileService.kt
@@ -1,7 +1,9 @@
 package com.vinnovateit.latch.features.wifi.quicksettings
 
+import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.service.quicksettings.Tile
 import android.service.quicksettings.TileService
 import android.util.Log
@@ -60,7 +62,18 @@ class LatchTileService : TileService() {
             val intent = Intent(android.provider.Settings.ACTION_WIFI_SETTINGS).apply {
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK
             }
-            startActivityAndCollapse(intent)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                val pendingIntent = PendingIntent.getActivity(
+                    this,
+                    0,
+                    intent,
+                    PendingIntent.FLAG_IMMUTABLE
+                )
+                startActivityAndCollapse(pendingIntent)
+            } else {
+                @Suppress("DEPRECATION")
+                startActivityAndCollapse(intent)
+            }
             return
         }
 


### PR DESCRIPTION
## What this fixes


- `LatchTileService.onClick()` calls `TileService.startActivityAndCollapse(Intent)` to open Wi-Fi settings when the tile is tapped while Wi-Fi is off. 

- That overload is deprecated as of API 34, and since this app's targetSdk is 36, it throws `UnsupportedOperationException` at runtime on any Android 14+ device instead of just producing a warning. 

- minSdk is 26, so the fix is version-gated: the new `PendingIntent` overload is used on API 34+, the old call remains for older devices.

- This is also what broke the `Android CI` on PR #49. `lintDebug` treats this as a build-breaking error (`StartActivityAndCollapseDeprecated`), not just a warning.

`main`'s own CI has been failing on this workflow for several pushes already.


## Testing


- `./gradlew :app:compileDebugKotlin` passes cleanly.
