### PR TITLE
Fix credentials validation bypass and onboarding slide skip

### DIFF
--- a/app/src/main/java/com/vinnovateit/latch/data/StoredCredentials.kt
+++ b/app/src/main/java/com/vinnovateit/latch/data/StoredCredentials.kt
@@ -41,13 +41,14 @@ object StoredCredentials {
         context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE).edit { clear() }
     }
 
-    fun saveCredentials(context: Context, userId: String, password: String) {
-        val prefs = getEncryptedPrefs(context)
-        prefs?.edit()
-            ?.putString(KEY_USER_ID, userId)
-            ?.putString(KEY_PASSWORD, password)
-            ?.apply()
+    fun saveCredentials(context: Context, userId: String, password: String): Boolean {
+        val prefs = getEncryptedPrefs(context) ?: return false
+        prefs.edit()
+            .putString(KEY_USER_ID, userId)
+            .putString(KEY_PASSWORD, password)
+            .apply()
         context.getSharedPreferences("app_prefs", Context.MODE_PRIVATE).edit().putBoolean("has_credentials", true).apply()
+        return true
     }
 
     fun getUserId(context: Context): String? {

--- a/app/src/main/java/com/vinnovateit/latch/features/onboarding/CredentialsActivity.kt
+++ b/app/src/main/java/com/vinnovateit/latch/features/onboarding/CredentialsActivity.kt
@@ -140,11 +140,14 @@ fun CredentialsScreen(editMode: Boolean, onCredentialsSaved: () -> Unit) {
                                     val year = regNo.substring(0, 2).toIntOrNull() ?: 99
                                     if (year <= 22) {
                                         regNoError = "Your college life is over... go find a job! 🎓"
-                                    }
-                                    scope.launch {
-                                        StoredCredentials.saveCredentials(context, regNo, password)
-                                        if (year <= 22) kotlinx.coroutines.delay(2000)
-                                        onCredentialsSaved()
+                                    } else {
+                                        scope.launch {
+                                            if (StoredCredentials.saveCredentials(context, regNo, password)) {
+                                                onCredentialsSaved()
+                                            } else {
+                                                passwordError = "Couldn't save credentials securely. Please try again."
+                                            }
+                                        }
                                     }
                                 }
                             } else {
@@ -227,11 +230,14 @@ fun CredentialsScreen(editMode: Boolean, onCredentialsSaved: () -> Unit) {
                                 val year = regNo.substring(0, 2).toIntOrNull() ?: 99
                                 if (year <= 22) {
                                     regNoError = "Your college life is over... go find a job! 🎓"
-                                }
-                                scope.launch {
-                                    StoredCredentials.saveCredentials(context, regNo, password)
-                                    if (year <= 22) kotlinx.coroutines.delay(2000)
-                                    onCredentialsSaved()
+                                } else {
+                                    scope.launch {
+                                        if (StoredCredentials.saveCredentials(context, regNo, password)) {
+                                            onCredentialsSaved()
+                                        } else {
+                                            passwordError = "Couldn't save credentials securely. Please try again."
+                                        }
+                                    }
                                 }
                             }
                         } else {

--- a/app/src/main/java/com/vinnovateit/latch/navigation/LatchNavGraph.kt
+++ b/app/src/main/java/com/vinnovateit/latch/navigation/LatchNavGraph.kt
@@ -114,7 +114,6 @@ fun LatchNavGraph(
 
         // Credentials screen
         composable(LatchRoutes.CREDENTIALS) { backStackEntry ->
-            val context = LocalContext.current
             val editMode = backStackEntry.arguments?.getString("editMode")?.toBoolean() ?: false
             CredentialsScreen(
                 editMode = editMode,
@@ -122,11 +121,11 @@ fun LatchNavGraph(
                     if (editMode) {
                         navController.popBackStack()
                     } else {
-                        val prefs = context.getSharedPreferences("app_prefs", android.content.Context.MODE_PRIVATE)
-                        prefs.edit().putBoolean("hasSeenOnboarding", true).apply()
-                        navController.navigate(LatchRoutes.HOME) {
-                            popUpTo(navController.graph.id) { inclusive = true }
-                        }
+                        // Return to the onboarding pager to let it finish its remaining
+                        // slides instead of jumping straight to Home; OnboardingScreen's
+                        // own onComplete() is what marks onboarding as seen and navigates
+                        // to Home once the pager itself finishes.
+                        navController.popBackStack(LatchRoutes.ONBOARDING, inclusive = false)
                     }
                 }
             )


### PR DESCRIPTION
## What this fixes


Three related bugs found in the onboarding/credentials save flow


- `CredentialsScreen`'s registration-year check (rejecting years ≤ 22 with "Your college life is over... go find a job!") sets an error message but the save-and-navigate call sat outside that check's `if` block in both the landscape and portrait layouts, so it ran regardless. The error is cosmetic: rejected credentials get saved and the app proceeds anyway.

- Saving credentials during onboarding pops the entire nav graph straight to Home, permanently skipping the onboarding pager's last two slides (widget/tile intro, completion screen). `OnboardingScreen` already has a `credentialsHandled` recheck effect written for exactly the "returned from credentials" case, but nothing in the nav graph ever actually returns to it.

- `StoredCredentials.saveCredentials()` always marked credentials as saved, even when the underlying `EncryptedSharedPreferences` write silently failed (Keystore/MasterKey error). A user hitting that edge case ends up with no stored credentials and no way to know why auto-login stopped working.


## Fixes


- Moved the save+navigate call into the `else` branch of the year check, in both layouts.

- Credentials-saved navigation during onboarding now pops back to the onboarding pager instead of jumping to Home, letting the pager's own completion flow (and its `hasSeenOnboarding` flag) run as originally intended.

- `saveCredentials()` now returns whether the write actually succeeded; the caller shows a real error instead of proceeding on failure.


## Testing


- `./gradlew :app:compileDebugKotlin` passes cleanly.
