### PR TITLE
Fix tile crash risk and wrong logout-vs-login branch

### DIFF
--- a/app/src/main/java/com/vinnovateit/latch/features/wifi/quicksettings/LatchTileService.kt
+++ b/app/src/main/java/com/vinnovateit/latch/features/wifi/quicksettings/LatchTileService.kt
@@ -44,6 +44,12 @@ class LatchTileService : TileService() {
     override fun onClick() {
         Log.d(TAG, "=== TILE CLICKED ===")
 
+        // SettingsManager may not have been initialized yet in this process (e.g. the
+        // tile is tapped right after a reboot, before MainActivity/ForegroundService/
+        // the widget ever ran) - setAutoLogin() below would crash on its lateinit
+        // sharedPreferences without this.
+        SettingsManager.initialize(applicationContext)
+
         if (isProcessing) {
             Log.d(TAG, "Already processing, ignoring click")
             return
@@ -72,8 +78,8 @@ class LatchTileService : TileService() {
                 val autoLoginEnabled = SettingsManager.autoLogin.value
                 val isConnected = SessionRepository.liveStatus.value != null
 
-                if (autoLoginEnabled || isConnected) {
-                    Log.d(TAG, "Currently connected or auto-login enabled. Triggering logout...")
+                if (isConnected) {
+                    Log.d(TAG, "Currently connected. Triggering logout...")
                     val intent = Intent(this@LatchTileService, ForegroundService::class.java).apply {
                         action = ForegroundService.ACTION_TRIGGER_LOGOUT
                     }


### PR DESCRIPTION
## What this fixes

Two related bugs in `LatchTileService`


- `SettingsManager.initialize()` is called from `MainActivity`, `ForegroundService`, and `LatchWidgetUpdater`, but never from `LatchTileService`. 

- Reading `SettingsManager.autoLogin.value` is safe (the `StateFlow` has a default), but `setAutoLogin()` writes through a `lateinit var sharedPreferences` that's only set inside `initialize()`. Tapping the Quick Settings tile before any other component has run in that process (e.g. right after a reboot) crashes with `UninitializedPropertyAccessException`.

- `onClick()`'s branch condition was `if (autoLoginEnabled || isConnected)`, routing to logout and disabling the user's auto-login preference whenever auto-login was on, even if the device wasn't actually connected yet. Tapping the tile mid-login sent a no-op logout intent and silently turned off auto-login instead of nudging the pending connection.


## Fixes


- `onClick()` now calls `SettingsManager.initialize(applicationContext)` defensively before touching any setting (cheap and safe to call redundantly, matching how the other call sites use it).

- The branch condition now depends only on `isConnected`, so the auto-login-disable side effect only fires on an actual logout.


## Testing


- `./gradlew :app:compileDebugKotlin` passes cleanly.

- Verified by reading `SettingsManager`'s `lateinit`/`initialize()` implementation and confirming the crash path.
