### PR TITLE
Fix session-start race and logout network-binding race

### DIFF
--- a/app/src/main/java/com/vinnovateit/latch/domain/model/SessionRepository.kt
+++ b/app/src/main/java/com/vinnovateit/latch/domain/model/SessionRepository.kt
@@ -36,6 +36,10 @@ object SessionRepository {
   private var sessionUpdateJob: Job? = null
   private val isInitialized = AtomicBoolean(false)
   private var notificationSent = false
+  // Atomically guards session start/stop so concurrent callers (network callback,
+  // health check, login re-validation) can't both pass the "no session yet" check
+  // and each start their own session against the same shared state.
+  private val sessionActive = AtomicBoolean(false)
 
   private val _liveStatus = MutableStateFlow<LiveConnectionStatus?>(null)
   val liveStatus = _liveStatus.asStateFlow()
@@ -78,8 +82,8 @@ object SessionRepository {
   }
 
   fun startSession(network: android.net.Network) {
-    if (sessionUpdateJob?.isActive == true || _liveStatus.value != null) return
-    val context = applicationContext ?: return
+    if (!sessionActive.compareAndSet(false, true)) return
+    val context = applicationContext ?: run { sessionActive.set(false); return }
     notificationSent = false
 
     val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as android.net.ConnectivityManager
@@ -124,8 +128,8 @@ object SessionRepository {
   }
 
   fun stopSession() {
+    if (!sessionActive.compareAndSet(true, false)) return
     val context = applicationContext ?: return
-    if (sessionUpdateJob == null && _liveStatus.value == null) return
     val sessionToFinalize = _liveStatus.value ?: return
 
     sessionUpdateJob?.cancel()

--- a/app/src/main/java/com/vinnovateit/latch/features/wifi/background/ForegroundService.kt
+++ b/app/src/main/java/com/vinnovateit/latch/features/wifi/background/ForegroundService.kt
@@ -24,6 +24,8 @@ import com.vinnovateit.latch.features.wifi.manager.ConnectionStatusManager
 import com.vinnovateit.latch.features.wifi.manager.LoginResult
 import com.vinnovateit.latch.features.wifi.manager.UiNotifier
 import kotlinx.coroutines.*
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -41,6 +43,13 @@ class ForegroundService : Service() {
 
     private var isNotificationHidden = false
     private var notificationUpdateJob: Job? = null
+
+    // Guards bindProcessToNetwork(...) usage: handleCaptivePortal() and logoutAndStop()
+    // both bind/unbind the process to a network around an HTTP request, and can run
+    // concurrently from independent coroutines (network callback, health check, manual
+    // login/logout intents) - without this, one can unbind the process out from under
+    // the other's in-flight request.
+    private val networkBindMutex = Mutex()
 
     companion object {
         const val ACTION_TRIGGER_LOGIN_CHECK = "com.vinnovateit.latch.ACTION_TRIGGER_LOGIN_CHECK"
@@ -294,31 +303,33 @@ class ForegroundService : Service() {
             ConnectionStatusManager.postStatus(
                 ConnectionStatus.Companion.Connecting(getString(R.string.status_authenticating))
             )
-            connectivityManager.bindProcessToNetwork(network)
-            try {
-                val user = StoredCredentials.getUserId(applicationContext)
-                val pass = StoredCredentials.getPassword(applicationContext)
-                if (user != null && pass != null) {
-                    val fallbackIp = getGatewayIp()
-                    when (AutoLoginManager.attemptLogin(user, pass, network, false, fallbackIp)) {
-                        is LoginResult.Success -> {
-                            Log.d("ForegroundService", "Login successful, re-validating network.")
-                            checkNetworkAndAct(network, true, notifyOnReconnect = notifyOnReconnect)
+            networkBindMutex.withLock {
+                connectivityManager.bindProcessToNetwork(network)
+                try {
+                    val user = StoredCredentials.getUserId(applicationContext)
+                    val pass = StoredCredentials.getPassword(applicationContext)
+                    if (user != null && pass != null) {
+                        val fallbackIp = getGatewayIp()
+                        when (AutoLoginManager.attemptLogin(user, pass, network, false, fallbackIp)) {
+                            is LoginResult.Success -> {
+                                Log.d("ForegroundService", "Login successful, re-validating network.")
+                                checkNetworkAndAct(network, true, notifyOnReconnect = notifyOnReconnect)
+                            }
+                            is LoginResult.Failure -> {
+                                ConnectionStatusManager.postStatus(ConnectionStatus.Failed(getString(R.string.status_login_failed)))
+                            }
                         }
-                        is LoginResult.Failure -> {
-                            ConnectionStatusManager.postStatus(ConnectionStatus.Failed(getString(R.string.status_login_failed)))
-                        }
+                    } else {
+                        ConnectionStatusManager.postStatus(ConnectionStatus.Failed(getString(R.string.status_login_failed)))
                     }
-                } else {
-                    ConnectionStatusManager.postStatus(ConnectionStatus.Failed(getString(R.string.status_login_failed)))
+                } finally {
+                    connectivityManager.bindProcessToNetwork(null)
                 }
-            } finally {
-                connectivityManager.bindProcessToNetwork(null)
             }
         }
     }
 
-    private fun logoutAndStop() {
+    private suspend fun logoutAndStop() {
         ConnectionStatusManager.postStatus(
             ConnectionStatus.Companion.Connecting(getString(R.string.status_logging_out))
         )
@@ -327,20 +338,22 @@ class ForegroundService : Service() {
         val network = currentWifiNetwork ?: connectivityManager.activeNetwork
 
         if (network != null) {
-            connectivityManager.bindProcessToNetwork(network)
-            try {
-                val fallbackIp = getGatewayIp()
-                val ok = AutoLoginManager.attemptLogout(false, fallbackIp)
-                if (ok) {
-                    Log.d("ForegroundService", "Logout success.")
-                    SessionRepository.stopSession()
-                    ConnectionStatusManager.postStatus(ConnectionStatus.Failed(getString(R.string.status_disconnected_message)))
-                } else {
-                    Log.w("ForegroundService", "Logout failed.")
-                    ConnectionStatusManager.postStatus(ConnectionStatus.Failed(getString(R.string.status_logout_failed)))
+            networkBindMutex.withLock {
+                connectivityManager.bindProcessToNetwork(network)
+                try {
+                    val fallbackIp = getGatewayIp()
+                    val ok = AutoLoginManager.attemptLogout(false, fallbackIp, network)
+                    if (ok) {
+                        Log.d("ForegroundService", "Logout success.")
+                        SessionRepository.stopSession()
+                        ConnectionStatusManager.postStatus(ConnectionStatus.Failed(getString(R.string.status_disconnected_message)))
+                    } else {
+                        Log.w("ForegroundService", "Logout failed.")
+                        ConnectionStatusManager.postStatus(ConnectionStatus.Failed(getString(R.string.status_logout_failed)))
+                    }
+                } finally {
+                    connectivityManager.bindProcessToNetwork(null)
                 }
-            } finally {
-                connectivityManager.bindProcessToNetwork(null)
             }
         } else {
             Log.w("ForegroundService", "No active network during logout.")

--- a/app/src/main/java/com/vinnovateit/latch/features/wifi/manager/AutoLoginManager.kt
+++ b/app/src/main/java/com/vinnovateit/latch/features/wifi/manager/AutoLoginManager.kt
@@ -115,14 +115,14 @@ object AutoLoginManager {
         }
     }
 
-    fun attemptLogout(useAlternate: Boolean = false, fallbackIp: String? = null): Boolean {
+    fun attemptLogout(useAlternate: Boolean = false, fallbackIp: String? = null, network: Network? = null): Boolean {
         logDebug("Initiating logout attempt (useAlternate=$useAlternate)")
         val targetUrlStr = if (useAlternate) SECURE_LOGOUT_URL else LOGOUT_URL
-        
+
         fun doAttempt(urlStr: String): Boolean {
             val url = URL(urlStr)
             logDebug("Opening connection to: $urlStr")
-            val connection = url.openConnection() as HttpURLConnection
+            val connection = (network?.openConnection(url) ?: url.openConnection()) as HttpURLConnection
             connection.requestMethod = "GET"
             connection.instanceFollowRedirects = false
             connection.connectTimeout = 10000


### PR DESCRIPTION
## What this fixes


Two concurrency bugs in the session-tracking and network-login code


- `SessionRepository.startSession()`'s entry guard (`if (sessionUpdateJob?.isActive == true || _liveStatus.value != null) return`) is a non-atomic check-then-act, callable concurrently from multiple `ForegroundService` coroutines (health check, login re-validation, network callback onAvailable). 

- Two callers racing through it can both pass the check and each start a session, attaching two `TrafficStatsLogger` collectors to the same flow and double-counting `rxBytes`/`txBytes` for the rest of the session.

- `AutoLoginManager.attemptLogout()` opened its connection with a plain `URL.openConnection()` instead of pinning to a `Network` the way `attemptLogin()` does, so it depended entirely on the process-wide `bindProcessToNetwork` state set by the caller. 

- `ForegroundService` has independent coroutines (health check, login, manual logout) that each bind/unbind that same process-wide state with no coordination between them, so a logout could race with another coroutine's unbind and go out over the wrong network (or none) while the UI still reported success.


## Fixes


- `startSession`/`stopSession` now guard entry with a single `AtomicBoolean` compare-and-set instead of two separately-checked fields, closing the race.

- `attemptLogout()` now accepts and pins to a `Network`, matching `attemptLogin()`'s existing pattern.

- `ForegroundService` serializes its two network-binding-sensitive sections (`handleCaptivePortal`, `logoutAndStop`) behind a `Mutex` so they can no longer interleave and disturb each other's process-wide bind state.


## Testing


- `./gradlew :app:compileDebugKotlin` passes cleanly.
