### PR TITLE
Fix inverted widget periodic-update scheduling

### DIFF
--- a/app/src/main/java/com/vinnovateit/latch/features/wifi/widget/LatchWidgetReceiver.kt
+++ b/app/src/main/java/com/vinnovateit/latch/features/wifi/widget/LatchWidgetReceiver.kt
@@ -28,10 +28,11 @@ class LatchWidgetReceiver : GlanceAppWidgetReceiver() {
   override fun onEnabled(context: Context) {
     super.onEnabled(context)
     LatchWidgetUpdater.enqueueOneTimeUpdate(context)
+    LatchWidgetUpdater.enqueuePeriodicUpdate(context)
   }
 
   override fun onDisabled(context: Context) {
     super.onDisabled(context)
-    LatchWidgetUpdater.enqueuePeriodicUpdate(context)
+    LatchWidgetUpdater.cancelPeriodicUpdate(context)
   }
 }

--- a/app/src/main/java/com/vinnovateit/latch/features/wifi/widget/LatchWidgetUpdater.kt
+++ b/app/src/main/java/com/vinnovateit/latch/features/wifi/widget/LatchWidgetUpdater.kt
@@ -39,15 +39,21 @@ class LatchWidgetUpdater(
       )
     }
 
+    private const val PERIODIC_UPDATE_WORK_NAME = "latch_widget_periodic_update"
+
     fun enqueuePeriodicUpdate(context: Context) {
       val periodicRequest = PeriodicWorkRequestBuilder<LatchWidgetUpdater>(
         15, TimeUnit.MINUTES
       ).build()
       WorkManager.getInstance(context).enqueueUniquePeriodicWork(
-        "latch_widget_periodic_update",
+        PERIODIC_UPDATE_WORK_NAME,
         ExistingPeriodicWorkPolicy.KEEP,
         periodicRequest
       )
+    }
+
+    fun cancelPeriodicUpdate(context: Context) {
+      WorkManager.getInstance(context).cancelUniqueWork(PERIODIC_UPDATE_WORK_NAME)
     }
   }
 


### PR DESCRIPTION
## What this fixes

`LatchWidgetReceiver`'s `onEnabled`/`onDisabled` had the periodic-update scheduling backwards.

- `onEnabled` (first widget instance placed on a home screen) only triggered a one-off update and never started the recurring refresh job.

- `onDisabled` (last widget instance removed) started the recurring 15-minute WorkManager job, and nothing ever cancelled it.

Net effect: a widget the user actually keeps on their home screen never gets periodic refreshes (only updates on the broadcasts already handled in `onReceive`), while removing the widget entirely kicks off an unkillable background job that runs forever.


## Fix


- `onEnabled` now enqueues both the immediate one-time update and the periodic update.
- `onDisabled` now cancels the periodic work instead of starting it. Added a `cancelPeriodicUpdate()` alongside the existing `enqueuePeriodicUpdate()` in `LatchWidgetUpdater`, using the same unique work name.


## Testing


- `./gradlew :app:compileDebugKotlin` passes cleanly.
