### PR TITLE
Remove destructive Room migration fallback

### DIFF
--- a/app/src/main/java/com/vinnovateit/latch/data/StatsDatabase.kt
+++ b/app/src/main/java/com/vinnovateit/latch/data/StatsDatabase.kt
@@ -96,7 +96,9 @@ abstract class LatchDatabase : RoomDatabase() {
           LatchDatabase::class.java,
           "latch_database"
         )
-          .fallbackToDestructiveMigration(false) // Handles schema change by rebuilding DB
+          // No destructive fallback: a future version bump without a real Migration
+          // should fail loudly during development instead of silently wiping every
+          // user's session history on update.
           .build()
         INSTANCE = instance
         instance


### PR DESCRIPTION
## What this fixes

- `LatchDatabase` (version 2) defines no `Migration` objects and calls `.fallbackToDestructiveMigration(false)`

- That call enables Room's destructive-fallback behavior (the boolean argument only controls whether non-Room-managed tables are also dropped, not whether the fallback itself is active)

- The inline comment "Handles schema change by rebuilding DB" misrepresents what that actually means: on the next version bump without a matching migration, every user's `sessions` and `daily_usage` history is wiped outright rather than migrated.

No version bump is happening in this PR, so this is a forward-looking safety change.


## Fix


Removed the destructive-fallback call entirely. A future version bump without a real `Migration` will now throw `IllegalStateException` during development, forcing a migration to be written, instead of silently deleting production data on update.


## Testing


- `./gradlew :app:compileDebugKotlin` passes cleanly.

- The database version isn't changing in this PR, so existing installs are unaffected.
