### PR TITLE
[Fix]: connect button using stale activeNetwork checks on captive-portal Wi-Fi

### DIFF
--- a/app/src/main/java/com/vinnovateit/latch/features/home/HomeScreen.kt
+++ b/app/src/main/java/com/vinnovateit/latch/features/home/HomeScreen.kt
@@ -59,6 +59,7 @@ import androidx.core.view.WindowCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import android.os.Build
 import android.provider.Settings
+import com.vinnovateit.latch.features.wifi.detector.WiFiConnectionDetector
 import com.vinnovateit.latch.features.wifi.detector.WiFiStateDetector
 import com.vinnovateit.latch.R
 import com.vinnovateit.latch.common.ui.LeafOverlay
@@ -116,10 +117,7 @@ fun HomeScreen(
         haptic.performHapticFeedback(HapticFeedbackType.LongPress)
         statusTimerTrigger = System.currentTimeMillis()
 
-        val connectivityManager = context.applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE) as android.net.ConnectivityManager
-        val activeNetwork = connectivityManager.activeNetwork
-        val networkCapabilities = connectivityManager.getNetworkCapabilities(activeNetwork)
-        val isWifiConnected = networkCapabilities?.hasTransport(android.net.NetworkCapabilities.TRANSPORT_WIFI) == true
+        val isWifiConnected = WiFiConnectionDetector.isConnectedToWiFi(context)
 
         if (!isConnected && (!WiFiStateDetector.isWiFiEnabled(context) || !isWifiConnected)) {
             val panelIntent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {

--- a/app/src/main/java/com/vinnovateit/latch/features/wifi/background/ForegroundService.kt
+++ b/app/src/main/java/com/vinnovateit/latch/features/wifi/background/ForegroundService.kt
@@ -201,9 +201,20 @@ class ForegroundService : Service() {
     }
 
     private fun getActiveWifiNetwork(): Network? {
+        // activeNetwork alone is not reliable here: a captive-portal Wi-Fi
+        // network (like VIT's) stays unvalidated until this service logs it
+        // in, so Android keeps mobile data as the "active" default network in
+        // the meantime. Fall back to scanning all networks for one with the
+        // Wi-Fi transport, same as WiFiConnectionDetector does for the UI check.
         val activeNetwork = connectivityManager.activeNetwork
-        val caps = connectivityManager.getNetworkCapabilities(activeNetwork)
-        return if (caps?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true) activeNetwork else null
+        val activeCaps = connectivityManager.getNetworkCapabilities(activeNetwork)
+        if (activeCaps?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true) {
+            return activeNetwork
+        }
+        return connectivityManager.allNetworks.firstOrNull { network ->
+            connectivityManager.getNetworkCapabilities(network)
+                ?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true
+        }
     }
 
     private fun checkNetworkAndAct(network: Network, isRevalidating: Boolean, retryCount: Int = 0, isSilent: Boolean = false) {


### PR DESCRIPTION
## What this fixes


- Connect opened the system Wi-Fi settings panel even when Wi-Fi was on and the VIT network was already connecting or connected.

- Workaround before this fix: turn Wi-Fi off, turn it back on, then press Connect.

- Even with the workaround, the first press said "Login Failed." Pressing Connect again immediately after said "Latched."


## Root cause


- `HomeScreen.kt`'s connect button checked Wi-Fi status using only `connectivityManager.activeNetwork`.

- VIT's Wi-Fi is a captive portal, so Android keeps mobile data as the active default network until Latch logs in and the portal validates. `activeNetwork` never reports Wi-Fi during that window.

- `ForegroundService.getActiveWifiNetwork()` had the same problem. It's the fallback used when the service's own `NetworkCallback` (`currentWifiNetwork`) hasn't fired yet, which is exactly the situation right when a fresh Connect press starts the service. It grabbed the wrong network (or none), the login request bound to it, and login failed. By the second press the callback had fired and `currentWifiNetwork` was used instead, so it worked immediately.

- `WiFiConnectionDetector.isConnectedToWiFi()` already existed elsewhere in the codebase and correctly falls back to scanning all networks for a Wi-Fi transport instead of trusting `activeNetwork` alone, but the connect button and the service fallback didn't use it.


## Fix


- `HomeScreen.kt`'s connect button now calls `WiFiConnectionDetector.isConnectedToWiFi()` instead of its own `activeNetwork`-only check.

- `ForegroundService.getActiveWifiNetwork()` now falls back to scanning all networks for a Wi-Fi transport, matching the same pattern.


## Testing


- `./gradlew :app:compileDebugKotlin` passes cleanly.

Fixes #57
