### PR TITLE
[Fix]: unguarded ACTION_VIEW intents in MeetTheTeamPage crashing without a resolvable app

### DIFF
--- a/app/src/main/java/com/vinnovateit/latch/features/about/MeetTheTeamPage.kt
+++ b/app/src/main/java/com/vinnovateit/latch/features/about/MeetTheTeamPage.kt
@@ -1,6 +1,9 @@
 package com.vinnovateit.latch.features.about
 
+import android.content.ActivityNotFoundException
+import android.content.Context
 import android.content.Intent
+import android.widget.Toast
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -39,6 +42,16 @@ import androidx.compose.ui.unit.sp
 import androidx.core.net.toUri
 import com.vinnovateit.latch.R
 import com.vinnovateit.latch.common.util.TooltipHint
+
+private fun openUrlSafely(context: Context, url: String, newTask: Boolean = false) {
+    try {
+        val intent = Intent(Intent.ACTION_VIEW, url.toUri())
+        if (newTask) intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        context.startActivity(intent)
+    } catch (e: ActivityNotFoundException) {
+        Toast.makeText(context, "No app found to open this link", Toast.LENGTH_SHORT).show()
+    }
+}
 
 data class TeamMember(
     val name: String,
@@ -99,8 +112,7 @@ fun MeetTheTeamPage(onBackClick: () -> Unit) {
                                 indication = null,
                                 interactionSource = remember { MutableInteractionSource() }
                             ) {
-                                val intent = Intent(Intent.ACTION_VIEW, "https://vinnovateit.com".toUri())
-                                context.startActivity(intent)
+                                openUrlSafely(context, "https://vinnovateit.com")
                             },
                         colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.primary)
                     )
@@ -121,8 +133,7 @@ fun MeetTheTeamPage(onBackClick: () -> Unit) {
                                 indication = null,
                                 interactionSource = remember { MutableInteractionSource() }
                             ) {
-                                val intent = Intent(Intent.ACTION_VIEW, "https://www.linkedin.com/company/v-innovate-it/".toUri())
-                                context.startActivity(intent)
+                                openUrlSafely(context, "https://www.linkedin.com/company/v-innovate-it/")
                             },
                         colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.primary)
                     )
@@ -135,8 +146,7 @@ fun MeetTheTeamPage(onBackClick: () -> Unit) {
                                 indication = null,
                                 interactionSource = remember { MutableInteractionSource() }
                             ) {
-                                val intent = Intent(Intent.ACTION_VIEW, "https://github.com/vinnovateit".toUri())
-                                context.startActivity(intent)
+                                openUrlSafely(context, "https://github.com/vinnovateit")
                             },
                         colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.primary)
                     )
@@ -149,8 +159,7 @@ fun MeetTheTeamPage(onBackClick: () -> Unit) {
                                 indication = null,
                                 interactionSource = remember { MutableInteractionSource() }
                             ) {
-                                val intent = Intent(Intent.ACTION_VIEW, "https://www.instagram.com/vinnovateit/".toUri())
-                                context.startActivity(intent)
+                                openUrlSafely(context, "https://www.instagram.com/vinnovateit/")
                             },
                         colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.primary)
                     )
@@ -331,9 +340,7 @@ fun TeamMemberCard(
                             interactionSource = remember { MutableInteractionSource() },
                             indication = null
                         ) {
-                            val intent = Intent(Intent.ACTION_VIEW, teamMember.githubUrl.toUri())
-                            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                            context.startActivity(intent)
+                            openUrlSafely(context, teamMember.githubUrl, newTask = true)
                         }
                 ) {
                     Image(
@@ -350,9 +357,7 @@ fun TeamMemberCard(
                             interactionSource = remember { MutableInteractionSource() },
                             indication = null
                         ) {
-                            val intent = Intent(Intent.ACTION_VIEW, teamMember.linkedinUrl.toUri())
-                            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                            context.startActivity(intent)
+                            openUrlSafely(context, teamMember.linkedinUrl, newTask = true)
                         }
                 ) {
                     Image(
@@ -406,11 +411,7 @@ fun ContributingSection() {
     // GitHub button
     OutlinedButton(
         onClick = {
-            val intent = Intent(
-                Intent.ACTION_VIEW,
-                "https://github.com/vinnovateit/latch".toUri()
-            )
-            context.startActivity(intent)
+            openUrlSafely(context, "https://github.com/vinnovateit/latch")
         },
         border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary),
         colors = ButtonDefaults.outlinedButtonColors(


### PR DESCRIPTION
## What this fixes

- The "Meet the Team" / about page had 8 places that built an `Intent(Intent.ACTION_VIEW, url)` and called `context.startActivity(intent)` directly, with no try/catch and no check that anything could handle the intent.

- If there's no app on the device that can resolve the intent, or a team member's URL string is malformed, `startActivity()` throws `ActivityNotFoundException` and crashes the whole app with no recovery.

## Change

- Added a shared `openUrlSafely(context, url, newTask)` helper that wraps `startActivity` in a try/catch for `ActivityNotFoundException` and shows a short toast instead of crashing.

- Replaced all 8 call sites (Vinnovate logo, LinkedIn/GitHub/Instagram company links, per-team-member GitHub/LinkedIn links, and the "Contribute on GitHub" button) with calls to the new helper.

Fixes #77
