### PR TITLE
Fix: Remove duplicate LaunchedEffect block in OnboardingScreen

### DIFF
--- a/app/src/main/java/com/vinnovateit/latch/features/onboarding/components/OnboardingScreen.kt
+++ b/app/src/main/java/com/vinnovateit/latch/features/onboarding/components/OnboardingScreen.kt
@@ -140,13 +140,6 @@ fun OnboardingScreen(
         }
     }
 
-    // credentialsHandled state should be checked if we return from credentials
-    LaunchedEffect(Unit) {
-        if (StoredCredentials.credentialsExist(context)) {
-            credentialsHandled = true
-        }
-    }
-
     if (isLandscape) {
         // --- NEW LANDSCAPE-ONLY UI ---
         Surface(


### PR DESCRIPTION
Closes #73

Removed the duplicate LaunchedEffect(Unit) block that re-checked 
StoredCredentials.credentialsExist(context). Kept the original block 
near the top of the composable.

Tested:
- Fresh install, no stored credentials — onboarding blocks correctly until credentials set
- Existing credentials — credentialsHandled resolves correctly, no block
- Return from credentials screen — credentialsHandled updates correctly, Next/Finish unlocks
- Verified in both portrait and landscape