### PR TITLE
fix(desktop): fix Linux menu freeze on first setup after login

### DIFF
--- a/desktop/src/commonMain/kotlin/com/vinnovateit/latch/desktop/LatchWindow.kt
+++ b/desktop/src/commonMain/kotlin/com/vinnovateit/latch/desktop/LatchWindow.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.window.WindowDraggableArea
 import androidx.compose.material3.MaterialTheme
@@ -12,6 +13,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
@@ -150,16 +152,17 @@ internal fun LatchWindow(
                 shape = RoundedCornerShape(WindowCornerRadius),
                 color = MaterialTheme.colorScheme.background,
             ) {
-                // WindowDraggableArea wraps everything so the top bar (which
-                // lives in commonMain and cannot call it directly) is draggable.
-                // Clicks pass through to children; only drag gestures are consumed.
-                WindowDraggableArea(modifier = Modifier.fillMaxSize()) {
-                    Box(modifier = Modifier.fillMaxSize()) {
-                        content(
-                            { state.isMinimized = true },
-                            onCloseRequest,
-                        )
-                    }
+                Box(modifier = Modifier.fillMaxSize()) {
+                    WindowDraggableArea(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(56.dp)
+                            .align(androidx.compose.ui.Alignment.TopStart),
+                    )
+                    content(
+                        { state.isMinimized = true },
+                        onCloseRequest,
+                    )
                 }
             }
         }

--- a/desktop/src/commonMain/kotlin/com/vinnovateit/latch/ui/components/LatchTopBar.kt
+++ b/desktop/src/commonMain/kotlin/com/vinnovateit/latch/ui/components/LatchTopBar.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.PopupProperties
 import com.vinnovateit.latch.desktop.LatchMark
 import com.vinnovateit.latch.desktop.resources.Res
 import com.vinnovateit.latch.desktop.resources.home_status_connected
@@ -180,6 +181,7 @@ internal fun LatchHomeTopBar(
                     shape = RoundedCornerShape(12.dp),
                     containerColor = MaterialTheme.colorScheme.surfaceContainer,
                     modifier = Modifier.width(200.dp),
+                    properties = PopupProperties(focusable = false),
                 ) {
                     if (showNavigationItems) {
                         DropdownMenuItem(


### PR DESCRIPTION
Fixes desktop top bar dropdown menu freezing on Linux after completing initial setup and login. Sets `PopupProperties(focusable = false)` on `DropdownMenu` to prevent AWT focus-stealing deadlocks on X11/Wayland, and restricts `WindowDraggableArea` to the top 56dp header rather than intercepting gestures across the whole window.