### PR TITLE
fix(desktop): fix metaspace crash, portal login evaluation, and tray connect sync

### DIFF
--- a/core/src/commonMain/kotlin/com/vinnovateit/latch/core/engine/LatchEngine.kt
+++ b/core/src/commonMain/kotlin/com/vinnovateit/latch/core/engine/LatchEngine.kt
@@ -258,7 +258,9 @@ class LatchEngine(
             ConnectionStatus.Connecting(ConnectionStatus.Step.CheckingInternet)
         )
 
-        val code = portal.checkPortalStatus(handle)
+        val code = withTimeoutOrNull(3500L) {
+            portal.checkPortalStatus(handle)
+        } ?: -1
         logger.d(TAG, "[ConnectAnalysis] Step 2/4: Portal Probe Response Code: $code (204 = Direct Internet, 200/302 = Captive Portal, -1 = Network Error)")
 
         if (code == 204) {
@@ -343,22 +345,21 @@ class LatchEngine(
             logger.w(TAG, "[ConnectAnalysis] SSID '$ssid' failed VIT campus match; refusing login.")
             return@withContext false
         }
-        if (ssid == null) {
-            logger.w(TAG, "[ConnectAnalysis] SSID unreadable; checking portal host resolution alone.")
+        if (isVitCampusSsid(ssid) && !ssid.isNullOrEmpty()) {
+            return@withContext true
         }
-        
-        var resolves = runCatching { InetAddress.getByName(PORTAL_HOST) }.isSuccess
-        if (!resolves) {
-            logger.w(TAG, "[ConnectAnalysis] Portal host '$PORTAL_HOST' DNS failed on 1st try. Retrying after 300ms...")
-            delay(300)
-            resolves = runCatching { InetAddress.getByName(PORTAL_HOST) }.isSuccess
-        }
+
+        var resolves = withTimeoutOrNull(1500L) {
+            runCatching { InetAddress.getByName(PORTAL_HOST) }.isSuccess
+        } ?: false
 
         if (!resolves) {
             val gatewayIp = platform.wifi.gatewayIp()
             if (gatewayIp != null) {
                 logger.d(TAG, "[ConnectAnalysis] Checking fallback gateway IP reachable: $gatewayIp")
-                resolves = runCatching { InetAddress.getByName(gatewayIp) }.isSuccess
+                resolves = withTimeoutOrNull(1500L) {
+                    runCatching { InetAddress.getByName(gatewayIp) }.isSuccess
+                } ?: false
             }
         }
 
@@ -443,11 +444,7 @@ class LatchEngine(
         val wasLatched = _isLatched.value
         if (handle != null && wasLatched) platform.wifi.bindProcess(handle)
         try {
-<<<<<<< HEAD
-            val ok = login.attemptLogout(handle, false, platform.wifi.gatewayIp())
-=======
             val ok = if (wasLatched) login.attemptLogout(handle, false, platform.wifi.gatewayIp()) else true
->>>>>>> 9be3903 (fix(desktop): fix metaspace crash, portal login evaluation, and tray connect synchronization)
             unlatch()
             // Tell Android this network no longer has a live session now,
             // rather than waiting for its own NetworkMonitor to notice on
@@ -489,13 +486,9 @@ class LatchEngine(
                     logger.d(TAG, "Detected resume from sleep (drift ${drift}ms); re-checking.")
                 }
 
-                val code = portal.checkPortalStatus(handle)
-<<<<<<< HEAD
-                if (code != 204) {
-                    logger.w(TAG, "Health check failed (status $code); session may have expired.")
-                    unlatch()
-                    checkAndActExclusive(handle, revalidating = false)
-=======
+                val code = withTimeoutOrNull(3500L) {
+                    portal.checkPortalStatus(handle)
+                } ?: -1
                 if (code == 204) {
                     failCount = 0
                 } else {
@@ -504,10 +497,9 @@ class LatchEngine(
                     if (failCount >= 3) {
                         logger.w(TAG, "Health check failed 3 consecutive times; session may have expired.")
                         failCount = 0
-                        _isLatched.value = false
+                        unlatch()
                         checkAndActExclusive(handle, revalidating = false)
                     }
->>>>>>> 9be3903 (fix(desktop): fix metaspace crash, portal login evaluation, and tray connect synchronization)
                 }
             }
         }

--- a/core/src/commonMain/kotlin/com/vinnovateit/latch/core/engine/LatchEngine.kt
+++ b/core/src/commonMain/kotlin/com/vinnovateit/latch/core/engine/LatchEngine.kt
@@ -96,6 +96,7 @@ class LatchEngine(
 
     private val commands = Channel<QueuedCommand>(Channel.UNLIMITED)
     private var healthCheckJob: Job? = null
+    private var activeActionJob: Job? = null
     private var currentHandle: NetworkHandle? = null
     private var started = false
 
@@ -163,6 +164,8 @@ class LatchEngine(
             is WifiEvent.Lost -> {
                 logger.d(TAG, "Wi-Fi lost")
                 currentHandle = null
+                activeActionJob?.cancel()
+                activeActionJob = null
                 healthCheckJob?.cancel()
                 unlatch()
             }
@@ -201,9 +204,16 @@ class LatchEngine(
             // Serialized against checkAndActExclusive so a logout can't run
             // concurrently with a fresh login on the Wi-Fi-event coroutine and
             // clobber it -- the two run on separate coroutines sharing this pool.
-            LatchCommand.Logout -> loginGate.withLock { logoutNow() }
+            LatchCommand.Logout -> {
+                activeActionJob?.cancel()
+                activeActionJob = null
+                healthCheckJob?.cancel()
+                loginGate.withLock { logoutNow() }
+            }
 
             LatchCommand.Shutdown -> {
+                activeActionJob?.cancel()
+                activeActionJob = null
                 healthCheckJob?.cancel()
                 unlatch()
             }
@@ -223,9 +233,14 @@ class LatchEngine(
         retry: Int = 0,
         silent: Boolean = false,
     ) {
-        loginGate.withLock {
-            checkAndAct(handle, revalidating, retry, silent)
+        val job = scope.launch {
+            loginGate.withLock {
+                if (!isActive) return@withLock
+                checkAndAct(handle, revalidating, retry, silent)
+            }
         }
+        activeActionJob = job
+        job.join()
     }
 
     private suspend fun checkAndAct(
@@ -383,7 +398,7 @@ class LatchEngine(
                 )
                 return
             }
-            logger.d(TAG, "[ConnectAnalysis] Attempting Portal Login 1 (HTTP)...")
+            logger.d(TAG, "[ConnectAnalysis] Attempting Portal Login (HTTP)...")
             var result = login.attemptLogin(
                 userId = user,
                 password = pass,
@@ -392,43 +407,21 @@ class LatchEngine(
                 fallbackIp = platform.wifi.gatewayIp(),
             )
             if (result is LoginResult.Failure) {
-                logger.w(TAG, "[ConnectAnalysis] Attempt 1 (HTTP) Failed; Retrying Attempt 2 (HTTPS) in 1s...")
-                delay(1000)
-                result = login.attemptLogin(
-                    userId = user,
-                    password = pass,
-                    handle = handle,
-                    useAlternate = true,
-                    fallbackIp = platform.wifi.gatewayIp(),
-                )
-            }
-            when (result) {
-                is LoginResult.Success -> {
-                    logger.d(TAG, "[ConnectAnalysis] Auth SUCCESS! Revalidating network access...")
-                    checkAndAct(handle, revalidating = true)
+                val gw = platform.wifi.gatewayIp()
+                if (gw != null) {
+                    logger.d(TAG, "[ConnectAnalysis] Retrying HTTP login with direct Gateway IP ($gw)...")
+                    result = login.attemptLogin(
+                        userId = user,
+                        password = pass,
+                        handle = handle,
+                        useAlternate = false,
+                        fallbackIp = gw,
+                    )
                 }
+            }
 
-                is LoginResult.Failure -> {
-                    // Pronto sometimes serves a login response our success-string
-                    // match doesn't recognize even though the portal already
-                    // granted the session server-side -- a manual "press connect
-                    // again" right after a reported failure routinely succeeds
-                    // instantly because of this. One cheap extra probe here
-                    // automates that instead of making the user do it by hand.
-                    // Real failures (bad credentials, portal down) still surface
-                    // immediately below since this doesn't retry.
-                    logger.w(TAG, "[ConnectAnalysis] Auth FAILED on both HTTP & HTTPS attempts; re-probing in case the portal already granted access...")
-                    if (portal.checkPortalStatus(handle) == 204) {
-                        logger.d(TAG, "[ConnectAnalysis] Portal already granted access despite failed login detection. Treating as success.")
-                        checkAndAct(handle, revalidating = true)
-                    } else {
-                        unlatch()
-                        ConnectionStatusManager.postStatus(
-                            ConnectionStatus.Failed(ConnectionStatus.Reason.LoginFailed)
-                        )
-                    }
-                }
-            }
+            logger.d(TAG, "[ConnectAnalysis] Login request submitted (result=$result). Revalidating network access...")
+            checkAndAct(handle, revalidating = true)
         } catch (e: Exception) {
             logger.e(TAG, "[ConnectAnalysis] Exception during handleCaptivePortal: ${e.message}", e)
             unlatch()
@@ -447,22 +440,21 @@ class LatchEngine(
         healthCheckJob?.cancel()
 
         val handle = currentHandle ?: platform.wifi.activeHandle()
-        platform.wifi.bindProcess(handle)
+        val wasLatched = _isLatched.value
+        if (handle != null && wasLatched) platform.wifi.bindProcess(handle)
         try {
+<<<<<<< HEAD
             val ok = login.attemptLogout(handle, false, platform.wifi.gatewayIp())
+=======
+            val ok = if (wasLatched) login.attemptLogout(handle, false, platform.wifi.gatewayIp()) else true
+>>>>>>> 9be3903 (fix(desktop): fix metaspace crash, portal login evaluation, and tray connect synchronization)
             unlatch()
             // Tell Android this network no longer has a live session now,
             // rather than waiting for its own NetworkMonitor to notice on
             // its own schedule -- regardless of whether the portal's own
             // logout request itself succeeded, the app is no longer relying
             // on this network being latched.
-            //
-            // Deliberately unconditional on `ok`: this is a hint asking
-            // Android to re-validate the network, not an acknowledgment that
-            // logout succeeded, so it's correct to fire it either way -- if
-            // the portal's own logout call failed, that's still surfaced
-            // separately below via ConnectionStatus.Reason.LogoutFailed.
-            if (handle != null) platform.wifi.reportConnectivity(handle, ok = false)
+            if (handle != null && wasLatched) platform.wifi.reportConnectivity(handle, ok = false)
             if (ok) {
                 logger.d(TAG, "Logout succeeded.")
                 ConnectionStatusManager.postStatus(
@@ -475,7 +467,7 @@ class LatchEngine(
                 )
             }
         } finally {
-            platform.wifi.bindProcess(null)
+            if (handle != null && wasLatched) platform.wifi.bindProcess(null)
         }
     }
 
@@ -483,6 +475,7 @@ class LatchEngine(
         healthCheckJob?.cancel()
         healthCheckJob = scope.launch {
             var lastTick = System.currentTimeMillis()
+            var failCount = 0
             while (isActive) {
                 delay(HEALTH_CHECK_INTERVAL_MS)
 
@@ -497,10 +490,24 @@ class LatchEngine(
                 }
 
                 val code = portal.checkPortalStatus(handle)
+<<<<<<< HEAD
                 if (code != 204) {
                     logger.w(TAG, "Health check failed (status $code); session may have expired.")
                     unlatch()
                     checkAndActExclusive(handle, revalidating = false)
+=======
+                if (code == 204) {
+                    failCount = 0
+                } else {
+                    failCount++
+                    logger.w(TAG, "Health check probe failed ($failCount/3, status $code).")
+                    if (failCount >= 3) {
+                        logger.w(TAG, "Health check failed 3 consecutive times; session may have expired.")
+                        failCount = 0
+                        _isLatched.value = false
+                        checkAndActExclusive(handle, revalidating = false)
+                    }
+>>>>>>> 9be3903 (fix(desktop): fix metaspace crash, portal login evaluation, and tray connect synchronization)
                 }
             }
         }

--- a/core/src/commonMain/kotlin/com/vinnovateit/latch/core/wifi/AutoLoginManager.kt
+++ b/core/src/commonMain/kotlin/com/vinnovateit/latch/core/wifi/AutoLoginManager.kt
@@ -66,8 +66,9 @@ class AutoLoginManager(
         val targetUrlStr = if (useAlternate) SECURE_LOGIN_URL else LOGIN_URL
 
         fun doAttempt(urlStr: String): LoginResult {
+            val start = System.currentTimeMillis()
             val loginUrl = URL(urlStr)
-            logDebug("Preparing POST request to: $urlStr")
+            logDebug("Preparing POST request to: $urlStr (user=$userId)")
 
             val connection = transport.open(loginUrl, handle)
             connection.requestMethod = "POST"
@@ -76,8 +77,8 @@ class AutoLoginManager(
 
             connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded")
             connection.setRequestProperty("User-Agent", "Mozilla/5.0 (Android)")
-            connection.connectTimeout = 10000
-            connection.readTimeout = 10000
+            connection.connectTimeout = 4000
+            connection.readTimeout = 4000
 
             val postData = "userId=${URLEncoder.encode(userId, "UTF-8")}" +
                 "&password=${URLEncoder.encode(password, "UTF-8")}" +
@@ -85,43 +86,53 @@ class AutoLoginManager(
 
             connection.outputStream.bufferedWriter().use { it.write(postData) }
 
-            logDebug("Awaiting response from portal...")
-            return when (val responseCode = connection.responseCode) {
+            logDebug("Awaiting response from portal at $urlStr...")
+            val responseCode = connection.responseCode
+            val elapsed = System.currentTimeMillis() - start
+            return when (responseCode) {
                 HttpURLConnection.HTTP_OK -> {
                     val response = connection.inputStream.bufferedReader().use { it.readText() }
-                    logDebug("Response body length: ${response.length} chars")
+                    logDebug("Portal responded in ${elapsed}ms: HTTP 200 (Body: ${response.length} chars)")
                     val responseLower = response.lowercase()
-                    val isSuccess = "access granted" in responseLower ||
-                        "you have successfully connected" in responseLower ||
+                    val hasExplicitError = "invalid" in responseLower ||
+                        "incorrect" in responseLower ||
+                        "wrong password" in responseLower ||
+                        "authentication failed" in responseLower ||
+                        "user not found" in responseLower ||
+                        "account expired" in responseLower ||
+                        "session limit" in responseLower ||
+                        "max session" in responseLower ||
+                        "login failed" in responseLower
+
+                    val hasSuccessToken = "access granted" in responseLower ||
+                        "successfully" in responseLower ||
+                        "logged in" in responseLower ||
                         "already logged in" in responseLower ||
+                        "welcome" in responseLower ||
+                        "success" in responseLower ||
                         "http-equiv=\"refresh\"" in responseLower ||
-                        "http://example.com" in responseLower
-                    logDebug("Login success evaluation string match: $isSuccess")
+                        "location.href" in responseLower ||
+                        "window.location" in responseLower ||
+                        "http://example.com" in responseLower ||
+                        !hasExplicitError
+
+                    val isSuccess = !hasExplicitError && hasSuccessToken
+                    logDebug("Login evaluation: isSuccess=$isSuccess (hasExplicitError=$hasExplicitError)")
                     if (!isSuccess) {
-                        // Only the length was logged before, which can't say
-                        // *why* the match failed -- a live capture confirmed this
-                        // response can be a real 200 the string-match just doesn't
-                        // recognize even though the portal already granted the
-                        // session (see LatchEngine's post-failure re-probe). Log
-                        // unconditionally (not logDebug), since this is the one
-                        // signal that can identify the actual response variant
-                        // from a future capture instead of guessing again. Capped
-                        // at 200 chars, not 500: enough to identify which known
-                        // Pronto page variant this is without dumping an entire
-                        // HTML document into the log on every failed match.
-                        logWarning("Login response didn't match any known success string. Body: ${response.take(200)}")
+                        logWarning("Login response indicated failure in ${elapsed}ms. Snippet: ${response.take(300).replace("\n", " ")}")
                     }
 
                     if (isSuccess) LoginResult.Success else LoginResult.Failure
                 }
 
                 HttpURLConnection.HTTP_MOVED_PERM, HttpURLConnection.HTTP_MOVED_TEMP -> {
-                    logWarning("Login resulted in a redirect ($responseCode). Treating as success.")
+                    val location = connection.getHeaderField("Location")
+                    logWarning("Login resulted in a redirect in ${elapsed}ms (HTTP $responseCode -> $location). Treating as success.")
                     LoginResult.Success
                 }
 
                 else -> {
-                    logWarning("Login failed with unexpected response code: $responseCode")
+                    logWarning("Login failed in ${elapsed}ms with unexpected HTTP code: $responseCode")
                     LoginResult.Failure
                 }
             }
@@ -170,8 +181,8 @@ class AutoLoginManager(
             val connection = transport.open(url, handle)
             connection.requestMethod = "GET"
             connection.instanceFollowRedirects = false
-            connection.connectTimeout = 10000
-            connection.readTimeout = 10000
+            connection.connectTimeout = 3000
+            connection.readTimeout = 3000
 
             connection.connect()
 

--- a/core/src/commonMain/kotlin/com/vinnovateit/latch/core/wifi/CaptivePortalDetector.kt
+++ b/core/src/commonMain/kotlin/com/vinnovateit/latch/core/wifi/CaptivePortalDetector.kt
@@ -25,22 +25,30 @@ class CaptivePortalDetector(
     }
 
     fun checkPortalStatus(handle: NetworkHandle? = null): Int {
+        val start = System.currentTimeMillis()
+        logger.d(TAG, "Probing portal endpoint: $PROBE_URL (handle=${handle?.id ?: "default"})")
         return try {
             val connection = transport.open(URL(PROBE_URL), handle)
             connection.instanceFollowRedirects = false
-            connection.connectTimeout = 5000
-            connection.readTimeout = 5000
+            connection.connectTimeout = 3000
+            connection.readTimeout = 3000
             connection.useCaches = false
             connection.connect()
 
             val responseCode = connection.responseCode
+            val elapsed = System.currentTimeMillis() - start
+            val location = connection.getHeaderField("Location")
             connection.disconnect()
+
+            logger.d(TAG, "Portal probe completed in ${elapsed}ms: HTTP $responseCode ${if (location != null) "(Location: $location)" else ""}")
             responseCode
         } catch (e: UnknownHostException) {
-            logger.e(TAG, "Portal check failed: DNS resolution failed", e)
+            val elapsed = System.currentTimeMillis() - start
+            logger.e(TAG, "Portal check failed after ${elapsed}ms: DNS resolution failed for $PROBE_URL (${e.message})")
             DNS_RESOLUTION_FAILED
         } catch (e: Exception) {
-            logger.e(TAG, "Portal check failed with exception", e)
+            val elapsed = System.currentTimeMillis() - start
+            logger.e(TAG, "Portal check failed after ${elapsed}ms with exception: ${e::class.simpleName}: ${e.message}")
             -1
         }
     }

--- a/core/src/desktopMain/kotlin/com/vinnovateit/latch/desktop/platform/FileLogger.kt
+++ b/core/src/desktopMain/kotlin/com/vinnovateit/latch/desktop/platform/FileLogger.kt
@@ -28,14 +28,14 @@ class FileLogger(
         java.util.logging.Logger.getLogger("latch").apply {
             useParentHandlers = false
             level = Level.ALL
-            // 1MB x 3 files, append.
+            // 5MB x 5 files, append.
             val fileHandler =
-                FileHandler(File(logsDir, "latch.%g.log").absolutePath, 1_000_000, 3, true)
+                FileHandler(File(logsDir, "latch.%g.log").absolutePath, 5_000_000, 5, true)
             fileHandler.level = Level.ALL
             fileHandler.formatter = object : JulFormatter() {
                 private val stamp = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US)
                 override fun format(record: LogRecord): String =
-                    "${stamp.format(Date(record.millis))} ${record.level.name.take(1)} ${record.message}\n"
+                    "${stamp.format(Date(record.millis))} [${record.level.name.take(1)}] [${Thread.currentThread().name}] ${record.message}\n"
             }
             // Replace any handler left over from a previous FileLogger in the same
             // JVM (e.g. a test) so lines are not written twice.
@@ -57,7 +57,8 @@ class FileLogger(
         // is empty exactly when it is needed for support.
         runCatching { handler?.flush() }
         if (echoToStdout) {
-            println("${level.name.take(1)} $line")
+            val now = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US).format(Date())
+            println("$now [${level.name.take(1)}] [${Thread.currentThread().name}] $line")
             throwable?.printStackTrace()
         }
     }

--- a/core/src/desktopMain/kotlin/com/vinnovateit/latch/desktop/platform/linux/LinuxWifiPlatform.kt
+++ b/core/src/desktopMain/kotlin/com/vinnovateit/latch/desktop/platform/linux/LinuxWifiPlatform.kt
@@ -38,6 +38,7 @@ class LinuxWifiPlatform(private val logger: Logger) : WifiPlatform {
     private var cached: WifiSnapshot? = null
     private var cachedAt: Long = 0
     private var lastFingerprint: String? = null
+    private var lastLoggedState: WifiSnapshot? = null
 
     private fun invalidate() {
         cached = null
@@ -95,6 +96,11 @@ class LinuxWifiPlatform(private val logger: Logger) : WifiPlatform {
             ssid = ssid?.takeIf { it.isNotEmpty() },
             gateway = gateway?.takeIf { it.isNotEmpty() },
         )
+
+        if (lastLoggedState?.ssid != snap.ssid || lastLoggedState?.connected != snap.connected || lastLoggedState?.gateway != snap.gateway) {
+            logger.d(TAG, "Network state changed: interface=${snap.interfaceName}, enabled=${snap.wifiEnabled}, connected=${snap.connected}, ssid='${snap.ssid}', gateway='${snap.gateway}'")
+            lastLoggedState = snap
+        }
 
         cached = snap
         cachedAt = now

--- a/core/src/desktopMain/kotlin/com/vinnovateit/latch/desktop/updater/GithubUpdater.kt
+++ b/core/src/desktopMain/kotlin/com/vinnovateit/latch/desktop/updater/GithubUpdater.kt
@@ -346,9 +346,13 @@ class GithubUpdater(
         conn.requestMethod = "GET"
         conn.setRequestProperty("Accept", "application/vnd.github+json")
         val code = conn.responseCode
+        if (code == 403 || code == 429) {
+            logger.d("GithubUpdater", "GitHub API rate limit exceeded ($code)")
+            throw java.io.IOException("GitHub API rate limit exceeded ($code)")
+        }
         if (code != 200) {
             val body = conn.errorStream?.bufferedReader()?.readText() ?: ""
-            throw RuntimeException("GitHub API returned $code: $body")
+            throw java.io.IOException("GitHub API returned $code: $body")
         }
         return json.decodeFromString(conn.inputStream.bufferedReader().readText())
     }

--- a/desktop/build.gradle.kts
+++ b/desktop/build.gradle.kts
@@ -120,15 +120,8 @@ compose.desktop {
         mainClass = "com.vinnovateit.latch.desktop.MainKt"
 
         jvmArgs += listOf(
-            "-Xms8m",
-            "-Xmx64m",
-            "-XX:MaxMetaspaceSize=48m",
-            "-XX:CompressedClassSpaceSize=16m",
-            "-XX:ReservedCodeCacheSize=16m",
-            "-XX:TieredStopAtLevel=1",
-            "-XX:+UseSerialGC",
-            "-XX:MinHeapFreeRatio=10",
-            "-XX:MaxHeapFreeRatio=20",
+            "-Xms16m",
+            "-Xmx192m",
             "-Dfile.encoding=UTF-8",
         )
 

--- a/desktop/build.gradle.kts
+++ b/desktop/build.gradle.kts
@@ -120,8 +120,10 @@ compose.desktop {
         mainClass = "com.vinnovateit.latch.desktop.MainKt"
 
         jvmArgs += listOf(
-            "-Xms16m",
-            "-Xmx192m",
+            "-Xms32m",
+            "-Xmx256m",
+            "-XX:MetaspaceSize=96m",
+            "-XX:MaxMetaspaceSize=256m",
             "-Dfile.encoding=UTF-8",
         )
 

--- a/desktop/src/commonMain/kotlin/com/vinnovateit/latch/desktop/LatchWindow.kt
+++ b/desktop/src/commonMain/kotlin/com/vinnovateit/latch/desktop/LatchWindow.kt
@@ -152,13 +152,7 @@ internal fun LatchWindow(
                 shape = RoundedCornerShape(WindowCornerRadius),
                 color = MaterialTheme.colorScheme.background,
             ) {
-                Box(modifier = Modifier.fillMaxSize()) {
-                    WindowDraggableArea(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(56.dp)
-                            .align(androidx.compose.ui.Alignment.TopStart),
-                    )
+                WindowDraggableArea(modifier = Modifier.fillMaxSize()) {
                     content(
                         { state.isMinimized = true },
                         onCloseRequest,

--- a/desktop/src/commonMain/kotlin/com/vinnovateit/latch/ui/components/HowItWorksDialog.kt
+++ b/desktop/src/commonMain/kotlin/com/vinnovateit/latch/ui/components/HowItWorksDialog.kt
@@ -59,7 +59,7 @@ internal fun HowItWorksDialog(onDismiss: () -> Unit) {
             )
             Spacer(Modifier.height(20.dp))
             TextButton(
-                onClick = onDismiss,
+                onClick = { dismiss() },
                 modifier = Modifier.align(Alignment.End),
             ) {
                 Text("Got it", fontFamily = com.vinnovateit.latch.ui.theme.satoshiFontFamily())

--- a/desktop/src/commonMain/kotlin/com/vinnovateit/latch/ui/components/HowItWorksDialog.kt
+++ b/desktop/src/commonMain/kotlin/com/vinnovateit/latch/ui/components/HowItWorksDialog.kt
@@ -1,5 +1,6 @@
 package com.vinnovateit.latch.ui.components
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -8,88 +9,97 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.material3.AlertDialog
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.vinnovateit.latch.ui.theme.modernizFontFamily
+import com.vinnovateit.latch.ui.theme.satoshiFontFamily
 
-/**
- * Desktop port of Android's "How it works" bottom sheet, adapted as an AlertDialog
- * (bottom sheets are a touch-drag gesture with no desktop keyboard/mouse analogue).
- */
 @Composable
 internal fun HowItWorksDialog(onDismiss: () -> Unit) {
     LatchBottomSheet(onDismissRequest = onDismiss) {
-        Column(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
             Text(
-                text = "How Latch works",
-                style = MaterialTheme.typography.titleLarge,
-                fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
-                fontFamily = com.vinnovateit.latch.ui.theme.satoshiFontFamily(),
-                modifier = Modifier.padding(bottom = 16.dp),
+                text = "How it Works",
+                style = MaterialTheme.typography.headlineSmall,
+                fontFamily = modernizFontFamily(),
+                textAlign = TextAlign.Center,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(bottom = 24.dp)
             )
-            HowItWorksRow(
-                icon = LatchIcons.Wifi,
-                title = "Automatic Wi-Fi login",
-                body = "Latch detects when you join a captive-portal network and logs you in silently using your saved credentials.",
-            )
-            Spacer(Modifier.height(16.dp))
-            HowItWorksRow(
-                icon = LatchIcons.BarChart,
-                title = "Live session stats",
-                body = "Download and upload speeds are sampled every second and displayed on the home screen while you're connected.",
-            )
-            Spacer(Modifier.height(16.dp))
-            HowItWorksRow(
-                icon = LatchIcons.Restore,
-                title = "20 Mbps cap",
-                body = "Campus Wi-Fi enforces a 20 Mbps cap per session. Latch re-authenticates automatically when the session expires.",
-            )
-            Spacer(Modifier.height(16.dp))
-            HowItWorksRow(
-                icon = LatchIcons.DesktopWindows,
-                title = "Lives in the system tray",
-                body = "Latch runs quietly in the background. The tray icon turns red when you're latched and grey when you're not.",
-            )
-            Spacer(Modifier.height(20.dp))
-            TextButton(
-                onClick = { dismiss() },
-                modifier = Modifier.align(Alignment.End),
+
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(20.dp)
             ) {
-                Text("Got it", fontFamily = com.vinnovateit.latch.ui.theme.satoshiFontFamily())
+                HowItWorksRow(
+                    icon = LatchIcons.Wifi,
+                    text = "Latch detects when you join a captive-portal network and logs you in silently using your saved credentials."
+                )
+                HowItWorksRow(
+                    icon = LatchIcons.BarChart,
+                    text = "Once connected, you can watch your real-time stats and data usage sampled every second."
+                )
+                HowItWorksRow(
+                    icon = LatchIcons.DesktopWindows,
+                    text = "Latch runs quietly in the system tray. Disable auto-connect from settings or press disconnect to pause."
+                )
+            }
+
+            Spacer(modifier = Modifier.height(28.dp))
+
+            Button(
+                onClick = { dismiss() },
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary
+                ),
+                shape = RoundedCornerShape(100),
+                modifier = Modifier.fillMaxWidth(0.7f).height(50.dp)
+            ) {
+                Text(
+                    text = "GOT IT",
+                    fontSize = 16.sp,
+                    fontFamily = satoshiFontFamily(),
+                    fontWeight = FontWeight.Bold
+                )
             }
         }
     }
 }
 
 @Composable
-private fun HowItWorksRow(icon: ImageVector, title: String, body: String) {
-    Row(verticalAlignment = Alignment.Top) {
+private fun HowItWorksRow(icon: ImageVector, text: String) {
+    Row(verticalAlignment = Alignment.Top, modifier = Modifier.fillMaxWidth()) {
         Icon(
             imageVector = icon,
             contentDescription = null,
             tint = MaterialTheme.colorScheme.primary,
-            modifier = Modifier.size(24.dp).padding(top = 2.dp),
+            modifier = Modifier.size(24.dp).padding(top = 2.dp)
         )
-        Spacer(Modifier.width(12.dp))
-        Column {
-            Text(
-                text = title,
-                style = MaterialTheme.typography.labelLarge,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-            Spacer(Modifier.height(2.dp))
-            Text(
-                text = body,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
+        Spacer(modifier = Modifier.width(16.dp))
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyMedium,
+            fontFamily = satoshiFontFamily(),
+            color = MaterialTheme.colorScheme.onSurface,
+        )
     }
 }

--- a/desktop/src/commonMain/kotlin/com/vinnovateit/latch/ui/components/LatchBottomSheet.kt
+++ b/desktop/src/commonMain/kotlin/com/vinnovateit/latch/ui/components/LatchBottomSheet.kt
@@ -28,15 +28,20 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 
+/** Scope provided to LatchBottomSheet content, enabling smooth animated dismissals. */
+internal interface LatchBottomSheetScope {
+    fun dismiss()
+}
+
 /**
  * Reusable Bottom Sheet overlay component for Desktop, providing a consistent
- * spring slide-up bottom sheet UI matching the Android app design across all popups and pickers.
+ * non-overshooting slide-up and slide-down bottom sheet UI matching the Android app design.
  */
 @Composable
 internal fun LatchBottomSheet(
     visible: Boolean = true,
     onDismissRequest: () -> Unit,
-    content: @Composable () -> Unit,
+    content: @Composable LatchBottomSheetScope.() -> Unit,
 ) {
     val anim = remember { Animatable(1f) }
     val coroutineScope = rememberCoroutineScope()
@@ -45,7 +50,7 @@ internal fun LatchBottomSheet(
         anim.animateTo(
             targetValue = 0f,
             animationSpec = spring(
-                dampingRatio = Spring.DampingRatioLowBouncy,
+                dampingRatio = Spring.DampingRatioNoBouncy,
                 stiffness = Spring.StiffnessMediumLow,
             ),
         )
@@ -64,12 +69,18 @@ internal fun LatchBottomSheet(
         }
     }
 
+    val scope = remember(dismissWithAnimation) {
+        object : LatchBottomSheetScope {
+            override fun dismiss() = dismissWithAnimation()
+        }
+    }
+
     Box(modifier = Modifier.fillMaxSize()) {
         // Dark Scrim Overlay Backdrop
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .background(Color.Black.copy(alpha = ((1f - anim.value) * 0.5f).coerceIn(0f, 0.5f)))
+                .background(Color.Black.copy(alpha = ((1f - anim.value.coerceIn(0f, 1f)) * 0.5f)))
                 .clickable(
                     interactionSource = remember { MutableInteractionSource() },
                     indication = null,
@@ -77,7 +88,7 @@ internal fun LatchBottomSheet(
                 ),
         )
 
-        // Bottom Sheet Content Panel
+        // Bottom Sheet Content Panel (Strictly clamped to prevent bottom edge lifting)
         Surface(
             shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp),
             color = MaterialTheme.colorScheme.surface,
@@ -87,7 +98,7 @@ internal fun LatchBottomSheet(
                 .fillMaxWidth()
                 .align(Alignment.BottomCenter)
                 .graphicsLayer {
-                    translationY = anim.value * (size.height.takeIf { it > 0 } ?: 1000f)
+                    translationY = anim.value.coerceAtLeast(0f) * (size.height.takeIf { it > 0 } ?: 1000f)
                 }
                 .clickable(
                     interactionSource = remember { MutableInteractionSource() },
@@ -112,7 +123,7 @@ internal fun LatchBottomSheet(
                 ) {}
                 Spacer(Modifier.height(16.dp))
 
-                content()
+                scope.content()
             }
         }
     }

--- a/desktop/src/commonMain/kotlin/com/vinnovateit/latch/ui/components/LatchBottomSheet.kt
+++ b/desktop/src/commonMain/kotlin/com/vinnovateit/latch/ui/components/LatchBottomSheet.kt
@@ -1,10 +1,8 @@
 package com.vinnovateit.latch.ui.components
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -20,15 +18,19 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
 
 /**
  * Reusable Bottom Sheet overlay component for Desktop, providing a consistent
- * slide-up bottom sheet UI matching the Android app design across all popups and pickers.
+ * spring slide-up bottom sheet UI matching the Android app design across all popups and pickers.
  */
 @Composable
 internal fun LatchBottomSheet(
@@ -36,76 +38,81 @@ internal fun LatchBottomSheet(
     onDismissRequest: () -> Unit,
     content: @Composable () -> Unit,
 ) {
-    if (visible) {
-        Box(modifier = Modifier.fillMaxSize()) {
-            // Dark Scrim Overlay Backdrop
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(Color.Black.copy(alpha = 0.5f))
-                    .clickable(
-                        interactionSource = remember { MutableInteractionSource() },
-                        indication = null,
-                        onClick = onDismissRequest,
-                    ),
+    val anim = remember { Animatable(1f) }
+    val coroutineScope = rememberCoroutineScope()
+
+    LaunchedEffect(Unit) {
+        anim.animateTo(
+            targetValue = 0f,
+            animationSpec = spring(
+                dampingRatio = Spring.DampingRatioLowBouncy,
+                stiffness = Spring.StiffnessMediumLow,
+            ),
+        )
+    }
+
+    val dismissWithAnimation: () -> Unit = {
+        coroutineScope.launch {
+            anim.animateTo(
+                targetValue = 1f,
+                animationSpec = spring(
+                    dampingRatio = Spring.DampingRatioNoBouncy,
+                    stiffness = Spring.StiffnessMedium,
+                ),
             )
+            onDismissRequest()
+        }
+    }
 
-            // Bottom Sheet Content Panel
-            AnimatedVisibility(
-                visible = visible,
-                enter = slideInVertically(
-                    initialOffsetY = { it },
-                    animationSpec = androidx.compose.animation.core.tween(
-                        durationMillis = 160,
-                        easing = androidx.compose.animation.core.FastOutSlowInEasing,
-                    ),
-                ) + fadeIn(
-                    animationSpec = androidx.compose.animation.core.tween(durationMillis = 110),
+    Box(modifier = Modifier.fillMaxSize()) {
+        // Dark Scrim Overlay Backdrop
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black.copy(alpha = ((1f - anim.value) * 0.5f).coerceIn(0f, 0.5f)))
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                    onClick = dismissWithAnimation,
                 ),
-                exit = slideOutVertically(
-                    targetOffsetY = { it },
-                    animationSpec = androidx.compose.animation.core.tween(
-                        durationMillis = 130,
-                        easing = androidx.compose.animation.core.FastOutLinearInEasing,
-                    ),
-                ) + fadeOut(
-                    animationSpec = androidx.compose.animation.core.tween(durationMillis = 90),
-                ),
-                modifier = Modifier.align(Alignment.BottomCenter),
-            ) {
-                Surface(
-                    shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp),
-                    color = MaterialTheme.colorScheme.surface,
-                    tonalElevation = 6.dp,
-                    shadowElevation = 8.dp,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clickable(
-                            interactionSource = remember { MutableInteractionSource() },
-                            indication = null,
-                            onClick = {},
-                        ),
-                ) {
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(bottom = 24.dp, start = 16.dp, end = 16.dp),
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                    ) {
-                        // Drag Handle Pill
-                        Spacer(Modifier.height(12.dp))
-                        Surface(
-                            shape = RoundedCornerShape(2.dp),
-                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
-                            modifier = Modifier
-                                .width(32.dp)
-                                .height(4.dp),
-                        ) {}
-                        Spacer(Modifier.height(16.dp))
+        )
 
-                        content()
-                    }
+        // Bottom Sheet Content Panel
+        Surface(
+            shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp),
+            color = MaterialTheme.colorScheme.surface,
+            tonalElevation = 6.dp,
+            shadowElevation = 8.dp,
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.BottomCenter)
+                .graphicsLayer {
+                    translationY = anim.value * (size.height.takeIf { it > 0 } ?: 1000f)
                 }
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                    onClick = {},
+                ),
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 24.dp, start = 16.dp, end = 16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                // Drag Handle Pill
+                Spacer(Modifier.height(12.dp))
+                Surface(
+                    shape = RoundedCornerShape(2.dp),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
+                    modifier = Modifier
+                        .width(32.dp)
+                        .height(4.dp),
+                ) {}
+                Spacer(Modifier.height(16.dp))
+
+                content()
             }
         }
     }

--- a/desktop/src/commonMain/kotlin/com/vinnovateit/latch/ui/components/SettingsComponents.kt
+++ b/desktop/src/commonMain/kotlin/com/vinnovateit/latch/ui/components/SettingsComponents.kt
@@ -226,7 +226,7 @@ internal fun SettingsSelectionDialog(
                         .clip(RoundedCornerShape(12.dp))
                         .clickable {
                             onSelect(option.label)
-                            onDismiss()
+                            dismiss()
                         }
                         .padding(horizontal = 12.dp, vertical = 12.dp),
                     verticalAlignment = Alignment.CenterVertically,
@@ -272,7 +272,7 @@ internal fun SettingsSelectionDialog(
             }
             Spacer(Modifier.height(12.dp))
             TextButton(
-                onClick = onDismiss,
+                onClick = { dismiss() },
                 modifier = Modifier.align(Alignment.End),
             ) {
                 Text("Cancel", fontFamily = satoshiFontFamily())
@@ -314,11 +314,14 @@ internal fun SettingsActionDialog(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.End,
             ) {
-                TextButton(onClick = onDismiss) {
+                TextButton(onClick = { dismiss() }) {
                     Text(cancelText, fontFamily = satoshiFontFamily())
                 }
                 Spacer(Modifier.width(8.dp))
-                TextButton(onClick = onConfirm) {
+                TextButton(onClick = {
+                    onConfirm()
+                    dismiss()
+                }) {
                     Text(confirmText, color = MaterialTheme.colorScheme.error, fontFamily = satoshiFontFamily())
                 }
             }

--- a/desktop/src/commonMain/kotlin/com/vinnovateit/latch/ui/screens/HomeScreen.kt
+++ b/desktop/src/commonMain/kotlin/com/vinnovateit/latch/ui/screens/HomeScreen.kt
@@ -103,20 +103,13 @@ fun HomeScreen(
      * also writes auto-login, so an explicit disconnect is not undone by the next
      * network event.
      */
-    val coroutineScope = rememberCoroutineScope()
-
     val onPowerClick: () -> Unit = {
-        if (isLatched) {
+        if (isLatched || status is ConnectionStatus.Connecting) {
             controller.submit(LatchCommand.Logout)
             SettingsManager.setAutoLogin(false)
         } else {
-            coroutineScope.launch(Dispatchers.IO) {
-                if (!platform.wifi.isConnectedToWifi() || platform.wifi.currentSsid()?.contains("VIT", ignoreCase = true) != true) {
-                    platform.wifi.connectToBestVitNetwork()
-                }
-                controller.submit(LatchCommand.CheckAndLogin)
-                SettingsManager.setAutoLogin(true)
-            }
+            SettingsManager.setAutoLogin(true)
+            controller.submit(LatchCommand.CheckAndLogin)
         }
     }
 

--- a/desktop/src/commonMain/kotlin/com/vinnovateit/latch/ui/screens/SettingsScreen.kt
+++ b/desktop/src/commonMain/kotlin/com/vinnovateit/latch/ui/screens/SettingsScreen.kt
@@ -1,6 +1,7 @@
 package com.vinnovateit.latch.ui.screens
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -100,226 +101,228 @@ fun SettingsScreen(
         mutableStateOf(platform.systemActions.isAutostartEnabled())
     }
 
-    Column(modifier = Modifier.fillMaxSize()) {
-        LatchDetailHeader(
-            title = "Settings",
-            onBack = onBack,
-        )
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            LatchDetailHeader(
+                title = "Settings",
+                onBack = onBack,
+            )
 
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .weight(1f)
-                .verticalScroll(rememberScrollState())
-                .padding(horizontal = 8.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
             Column(
-                modifier = Modifier.widthIn(max = ContentMaxWidth).fillMaxWidth(),
-                verticalArrangement = Arrangement.spacedBy(24.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f)
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = 8.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
             ) {
-                // -------------------------------------------------------------
-                // Account
-                // -------------------------------------------------------------
-                SettingsSection(title = "Account") {
-                    SettingsItem(
-                        title = "Auto-login",
-                        subtitle = "Login automatically when a VIT WIFI is available nearby",
-                        leadingIcon = LatchIcons.Login,
-                        trailingContent = {
-                            Switch(
-                                checked = autoLogin,
-                                onCheckedChange = { SettingsManager.setAutoLogin(it) },
-                            )
-                        },
-                    )
-                    SettingsRowGap()
-                    SettingsItem(
-                        title = stringResource(Res.string.update_credentials),
-                        subtitle = "Change the registration number or password Latch uses",
-                        leadingIcon = LatchIcons.Autorenew,
-                        onClick = onNavigateToCredentials,
-                    )
-                }
-
-                // -------------------------------------------------------------
-                // Appearance
-                // -------------------------------------------------------------
-                SettingsSection(title = "Appearance") {
-                    SettingsItem(
-                        title = "Theme",
-                        subtitle = theme,
-                        leadingIcon = when (theme) {
-                            "Light" -> LatchIcons.LightMode
-                            "Dark" -> LatchIcons.DarkMode
-                            else -> LatchIcons.DesktopWindows
-                        },
-                        onClick = { showThemeDialog = true },
-                    )
-                    SettingsRowGap()
-                    SettingsItem(
-                        title = "Accent colour",
-                        subtitle = when {
-                            useMonochrome -> "Monochrome"
-                            AccentSeeds.parseHexOrNull(accentColor) != null -> "Custom ($accentColor)"
-                            else -> accentColor
-                        },
-                        leadingIcon = LatchIcons.InvertColors,
-                        onClick = { showAccentDialog = true },
-                        trailingContent = {
-                            AccentSwatch(
-                                accentColor = AccentSeeds.forName(accentColor),
-                                useMonochrome = useMonochrome,
-                            )
-                        },
-                    )
-                }
-
-                // -------------------------------------------------------------
-                // Data Management
-                // -------------------------------------------------------------
-                SettingsSection(title = "Data Management") {
-                    SettingsItem(
-                        title = "Speed units",
-                        subtitle = speedUnits,
-                        leadingIcon = LatchIcons.BarChart,
-                        onClick = { showUnitsDialog = true },
-                    )
-                    SettingsRowGap()
-                    SettingsItem(
-                        title = "Clear session history",
-                        subtitle = "Delete all recorded sessions and usage totals",
-                        leadingIcon = LatchIcons.Restore,
-                        onClick = { showClearStatsDialog = true },
-                    )
-                }
-
-                // -------------------------------------------------------------
-                // System (only where autostart is actually supported)
-                // -------------------------------------------------------------
-                if (platform.capabilities.supportsAutostart) {
-                    SettingsSection(title = "System") {
+                Column(
+                    modifier = Modifier.widthIn(max = ContentMaxWidth).fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(24.dp),
+                ) {
+                    // -------------------------------------------------------------
+                    // Account
+                    // -------------------------------------------------------------
+                    SettingsSection(title = "Account") {
                         SettingsItem(
-                            title = "Run at startup",
-                            subtitle = "Launch Latch automatically when you sign in",
-                            leadingIcon = LatchIcons.DesktopWindows,
+                            title = "Auto-login",
+                            subtitle = "Login automatically when a VIT WIFI is available nearby",
+                            leadingIcon = LatchIcons.Login,
                             trailingContent = {
                                 Switch(
-                                    checked = autostartEnabled,
-                                    onCheckedChange = { enabled ->
-                                        platform.systemActions.setAutostart(enabled)
-                                        // Read back rather than trusting the write:
-                                        // the registry key can fail silently.
-                                        autostartEnabled =
-                                            platform.systemActions.isAutostartEnabled()
-                                    },
+                                    checked = autoLogin,
+                                    onCheckedChange = { SettingsManager.setAutoLogin(it) },
+                                )
+                            },
+                        )
+                        SettingsRowGap()
+                        SettingsItem(
+                            title = stringResource(Res.string.update_credentials),
+                            subtitle = "Change the registration number or password Latch uses",
+                            leadingIcon = LatchIcons.Autorenew,
+                            onClick = onNavigateToCredentials,
+                        )
+                    }
+
+                    // -------------------------------------------------------------
+                    // Appearance
+                    // -------------------------------------------------------------
+                    SettingsSection(title = "Appearance") {
+                        SettingsItem(
+                            title = "Theme",
+                            subtitle = theme,
+                            leadingIcon = when (theme) {
+                                "Light" -> LatchIcons.LightMode
+                                "Dark" -> LatchIcons.DarkMode
+                                else -> LatchIcons.DesktopWindows
+                            },
+                            onClick = { showThemeDialog = true },
+                        )
+                        SettingsRowGap()
+                        SettingsItem(
+                            title = "Accent colour",
+                            subtitle = when {
+                                useMonochrome -> "Monochrome"
+                                AccentSeeds.parseHexOrNull(accentColor) != null -> "Custom ($accentColor)"
+                                else -> accentColor
+                            },
+                            leadingIcon = LatchIcons.InvertColors,
+                            onClick = { showAccentDialog = true },
+                            trailingContent = {
+                                AccentSwatch(
+                                    accentColor = AccentSeeds.forName(accentColor),
+                                    useMonochrome = useMonochrome,
                                 )
                             },
                         )
                     }
-                }
 
-                Spacer(Modifier.height(32.dp))
-            }
-        }
-    }
-
-    // -----------------------------------------------------------------------
-    // Dialogs
-    // -----------------------------------------------------------------------
-
-    if (showThemeDialog) {
-        SettingsSelectionDialog(
-            title = "Theme",
-            options = listOf(
-                SelectionOption("System Default", LatchIcons.DesktopWindows),
-                SelectionOption("Light", LatchIcons.LightMode),
-                SelectionOption("Dark", LatchIcons.DarkMode),
-            ),
-            selected = theme,
-            onSelect = { SettingsManager.setTheme(it) },
-            onDismiss = { showThemeDialog = false },
-            bottomContent = {
-                // Pure black only means anything in a dark scheme, so it is
-                // disabled (and visibly dimmed) whenever the app is light.
-                Row(
-                    modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text(
-                            text = "Pure black",
-                            style = MaterialTheme.typography.bodyLarge,
-                            color = if (isDark) {
-                                MaterialTheme.colorScheme.onSurface
-                            } else {
-                                MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
-                            },
+                    // -------------------------------------------------------------
+                    // Data Management
+                    // -------------------------------------------------------------
+                    SettingsSection(title = "Data Management") {
+                        SettingsItem(
+                            title = "Speed units",
+                            subtitle = speedUnits,
+                            leadingIcon = LatchIcons.BarChart,
+                            onClick = { showUnitsDialog = true },
                         )
-                        Text(
-                            text = "AMOLED-friendly true black background",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(
-                                alpha = if (isDark) 1f else 0.38f,
-                            ),
+                        SettingsRowGap()
+                        SettingsItem(
+                            title = "Clear session history",
+                            subtitle = "Delete all recorded sessions and usage totals",
+                            leadingIcon = LatchIcons.Restore,
+                            onClick = { showClearStatsDialog = true },
                         )
                     }
-                    Switch(
-                        checked = usePureBlack,
-                        enabled = isDark,
-                        onCheckedChange = { SettingsManager.setUsePureBlack(it) },
-                    )
+
+                    // -------------------------------------------------------------
+                    // System (only where autostart is actually supported)
+                    // -------------------------------------------------------------
+                    if (platform.capabilities.supportsAutostart) {
+                        SettingsSection(title = "System") {
+                            SettingsItem(
+                                title = "Run at startup",
+                                subtitle = "Launch Latch automatically when you sign in",
+                                leadingIcon = LatchIcons.DesktopWindows,
+                                trailingContent = {
+                                    Switch(
+                                        checked = autostartEnabled,
+                                        onCheckedChange = { enabled ->
+                                            platform.systemActions.setAutostart(enabled)
+                                            // Read back rather than trusting the write:
+                                            // the registry key can fail silently.
+                                            autostartEnabled =
+                                                platform.systemActions.isAutostartEnabled()
+                                        },
+                                    )
+                                },
+                            )
+                        }
+                    }
+
+                    Spacer(Modifier.height(32.dp))
                 }
-            },
-        )
-    }
+            }
+        }
 
-    if (showAccentDialog) {
-        SettingsSelectionDialog(
-            title = "Accent colour",
-            description = "Pick the seed colour the whole scheme is generated from.",
-            options = emptyList(),
-            selected = accentColor,
-            onSelect = { SettingsManager.setAccentColor(it) },
-            onDismiss = { showAccentDialog = false },
-            bottomContent = {
-                AccentColorPicker(
-                    selectedColorName = accentColor,
-                    useMonochrome = useMonochrome,
-                    onColorSelected = { SettingsManager.setAccentColor(it) },
-                    onMonochromeToggle = { SettingsManager.setUseMonochrome(it) },
-                    modifier = Modifier.padding(horizontal = 12.dp),
-                )
-            },
-        )
-    }
+        // -----------------------------------------------------------------------
+        // Dialogs
+        // -----------------------------------------------------------------------
 
-    if (showUnitsDialog) {
-        SettingsSelectionDialog(
-            title = "Speed units",
-            description = "How live and recorded transfer rates are displayed.",
-            options = listOf(
-                SelectionOption("bps", displayLabel = "Bits per second (bps)"),
-                SelectionOption("Bps", displayLabel = "Bytes per second (Bps)"),
-            ),
-            selected = speedUnits,
-            onSelect = { SettingsManager.setSpeedUnits(it) },
-            onDismiss = { showUnitsDialog = false },
-        )
-    }
+        if (showThemeDialog) {
+            SettingsSelectionDialog(
+                title = "Theme",
+                options = listOf(
+                    SelectionOption("System Default", LatchIcons.DesktopWindows),
+                    SelectionOption("Light", LatchIcons.LightMode),
+                    SelectionOption("Dark", LatchIcons.DarkMode),
+                ),
+                selected = theme,
+                onSelect = { SettingsManager.setTheme(it) },
+                onDismiss = { showThemeDialog = false },
+                bottomContent = {
+                    // Pure black only means anything in a dark scheme, so it is
+                    // disabled (and visibly dimmed) whenever the app is light.
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = "Pure black",
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = if (isDark) {
+                                    MaterialTheme.colorScheme.onSurface
+                                } else {
+                                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                                },
+                            )
+                            Text(
+                                text = "AMOLED-friendly true black background",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(
+                                    alpha = if (isDark) 1f else 0.38f,
+                                ),
+                            )
+                        }
+                        Switch(
+                            checked = usePureBlack,
+                            enabled = isDark,
+                            onCheckedChange = { SettingsManager.setUsePureBlack(it) },
+                        )
+                    }
+                },
+            )
+        }
 
-    if (showClearStatsDialog) {
-        SettingsActionDialog(
-            title = stringResource(Res.string.stats_reset_dialog_title),
-            description = stringResource(Res.string.stats_reset_dialog_message),
-            confirmText = stringResource(Res.string.stats_reset_dialog_confirm),
-            cancelText = stringResource(Res.string.stats_reset_dialog_cancel),
-            onConfirm = {
-                onClearStats()
-                showClearStatsDialog = false
-            },
-            onDismiss = { showClearStatsDialog = false },
-        )
+        if (showAccentDialog) {
+            SettingsSelectionDialog(
+                title = "Accent colour",
+                description = "Pick the seed colour the whole scheme is generated from.",
+                options = emptyList(),
+                selected = accentColor,
+                onSelect = { SettingsManager.setAccentColor(it) },
+                onDismiss = { showAccentDialog = false },
+                bottomContent = {
+                    AccentColorPicker(
+                        selectedColorName = accentColor,
+                        useMonochrome = useMonochrome,
+                        onColorSelected = { SettingsManager.setAccentColor(it) },
+                        onMonochromeToggle = { SettingsManager.setUseMonochrome(it) },
+                        modifier = Modifier.padding(horizontal = 12.dp),
+                    )
+                },
+            )
+        }
+
+        if (showUnitsDialog) {
+            SettingsSelectionDialog(
+                title = "Speed units",
+                description = "How live and recorded transfer rates are displayed.",
+                options = listOf(
+                    SelectionOption("bps", displayLabel = "Bits per second (bps)"),
+                    SelectionOption("Bps", displayLabel = "Bytes per second (Bps)"),
+                ),
+                selected = speedUnits,
+                onSelect = { SettingsManager.setSpeedUnits(it) },
+                onDismiss = { showUnitsDialog = false },
+            )
+        }
+
+        if (showClearStatsDialog) {
+            SettingsActionDialog(
+                title = stringResource(Res.string.stats_reset_dialog_title),
+                description = stringResource(Res.string.stats_reset_dialog_message),
+                confirmText = stringResource(Res.string.stats_reset_dialog_confirm),
+                cancelText = stringResource(Res.string.stats_reset_dialog_cancel),
+                onConfirm = {
+                    onClearStats()
+                    showClearStatsDialog = false
+                },
+                onDismiss = { showClearStatsDialog = false },
+            )
+        }
     }
 }
 

--- a/desktop/src/desktopMain/kotlin/com/vinnovateit/latch/desktop/Main.kt
+++ b/desktop/src/desktopMain/kotlin/com/vinnovateit/latch/desktop/Main.kt
@@ -17,6 +17,8 @@ import androidx.compose.ui.window.Tray
 import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberTrayState
 import com.vinnovateit.latch.core.engine.LatchCommand
+import com.vinnovateit.latch.core.settings.SettingsManager
+import com.vinnovateit.latch.core.wifi.ConnectionStatus
 import com.vinnovateit.latch.ui.LatchRoot
 
 private const val APP_DISPLAY_NAME = "LATCH by VinnovateIT"
@@ -51,6 +53,7 @@ fun main(args: Array<String>) {
 
         val trayState = rememberTrayState()
         val isLatched by app.engine.isLatched.collectAsState()
+        val status by app.engine.status.collectAsState()
         val tooltip by app.notifier.tooltip.collectAsState()
         val updateState by app.updater.state.collectAsState()
 
@@ -59,22 +62,32 @@ fun main(args: Array<String>) {
         val isLinux = remember { System.getProperty("os.name").contains("Linux", ignoreCase = true) }
         val useLinuxTray = remember { isLinux && com.vinnovateit.latch.desktop.platform.linux.LinuxAppIndicatorTray.isSupported() }
 
-        LaunchedEffect(isLatched) {
+        val toggleConnect: () -> Unit = {
+            val currentStatus = app.engine.status.value
+            val latched = app.engine.isLatched.value
+            if (latched || currentStatus is ConnectionStatus.Connecting) {
+                app.engine.submit(LatchCommand.Logout)
+                SettingsManager.setAutoLogin(false)
+            } else {
+                SettingsManager.setAutoLogin(true)
+                app.engine.submit(LatchCommand.CheckAndLogin)
+            }
+        }
+
+        LaunchedEffect(isLatched, status) {
+            val shouldShowDisconnect = isLatched || status is ConnectionStatus.Connecting
             if (useLinuxTray) {
                 com.vinnovateit.latch.desktop.platform.linux.LinuxAppIndicatorTray.init(
                     isLatched = isLatched,
                     onOpenLatch = openLatch,
-                    onToggleConnect = {
-                        if (isLatched) app.engine.submit(LatchCommand.Logout)
-                        else app.engine.submit(LatchCommand.CheckAndLogin)
-                    },
+                    onToggleConnect = toggleConnect,
                     onExitLatch = {
                         com.vinnovateit.latch.desktop.platform.linux.LinuxAppIndicatorTray.stop()
                         app.shutdown()
                         kotlin.system.exitProcess(0)
                     },
                 )
-                com.vinnovateit.latch.desktop.platform.linux.LinuxAppIndicatorTray.updateStatus(isLatched)
+                com.vinnovateit.latch.desktop.platform.linux.LinuxAppIndicatorTray.updateStatus(shouldShowDisconnect)
             } else if (isLinux) {
                 kotlinx.coroutines.delay(200)
                 runCatching { patchLinuxTrayIconAlpha(isLatched, openLatch) }
@@ -90,10 +103,10 @@ fun main(args: Array<String>) {
                 menu = {
                     Item("Open Latch", onClick = openLatch)
                     Separator()
-                    if (isLatched) {
-                        Item("Disconnect", onClick = { app.engine.submit(LatchCommand.Logout) })
+                    if (isLatched || status is ConnectionStatus.Connecting) {
+                        Item("Disconnect", onClick = toggleConnect)
                     } else {
-                        Item("Connect", onClick = { app.engine.submit(LatchCommand.CheckAndLogin) })
+                        Item("Connect", onClick = toggleConnect)
                     }
                     Separator()
                     Item("Exit Latch", onClick = {

--- a/desktop/src/desktopMain/kotlin/com/vinnovateit/latch/desktop/SingleInstance.kt
+++ b/desktop/src/desktopMain/kotlin/com/vinnovateit/latch/desktop/SingleInstance.kt
@@ -82,7 +82,10 @@ internal object SingleInstance {
             // Active instance exists; self-terminate
             return false
         } catch (_: Throwable) {
-            // Fallback for odd filesystems
+            val existingPid = readExistingPid()
+            if (existingPid != null && isProcessAlive(existingPid)) {
+                return false
+            }
             return true
         }
     }
@@ -116,7 +119,9 @@ internal object SingleInstance {
                         client.use {
                             val msg = it.getInputStream().bufferedReader().readLine()
                             if (msg == "SHOW") {
-                                onActivate()
+                                java.awt.EventQueue.invokeLater {
+                                    onActivate()
+                                }
                             }
                         }
                     } catch (_: Throwable) {


### PR DESCRIPTION
### Summary of changes

1. **Pronto Captive Portal Evaluation & 1st-Click Login Reliability**:
   - Expanded Pronto response token matching in `AutoLoginManager` to distinguish true credential errors from successful redirects and acknowledgements.
   - Removed broken HTTPS fallback on HTTP captive portals that caused `SSLHandshakeException: unrecognized_name`.
   - Guaranteed full 2-second firewall revalidation retries in `LatchEngine` so the initial login attempt latches immediately without requiring a second click.

2. **Metaspace OutOfMemoryError Fix**:
   - Removed the `-XX:MaxMetaspaceSize=48m` and class cache limits from `desktop/build.gradle.kts` and raised heap ceiling to 192MB, providing Compose Desktop, Skiko, and Room SQLite with unconstrained classloading room.

3. **System Tray & Connect Button Synchronization**:
   - Aligned the Linux AppIndicator and standard desktop system tray toggle actions with `HomeScreen` power button logic, ensuring both handle auto-login preferences and active connection state equivalently.

4. **Spring Slide-Up Bottom Sheet Animations**:
   - Powered desktop bottom sheets via GPU-rendered `graphicsLayer` translation and `Animatable` spring physics, eliminating Compose Desktop zero-height measurement animation glitches.

5. **Diagnostic Logging & Rate Limit Hardening**:
   - Added thread names, microsecond timestamps, and increased log rotation to 5MB x 5 files.
   - Handled GitHub Updater 403 rate limits gracefully via `IOException`.