### PR TITLE
[chore]: add dependabot config and security policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+    labels: ["dependencies", "gradle"]
+    commit-message:
+      prefix: "deps(gradle)"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+    labels: ["dependencies", "github-actions"]
+    commit-message:
+      prefix: "deps(actions)"
+    open-pull-requests-limit: 5

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+## Supported Versions
+
+We release patches for security vulnerabilities in the latest stable release only.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| Latest  | :white_check_mark: |
+| Older   | :x:                |
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities by opening a [GitHub Security Advisory](https://github.com/vinnovateit/latch/security/advisories/new).
+
+Do **not** open a public issue for security vulnerabilities.
+
+We will acknowledge your receipt and get back to you within 2-3 working days.


### PR DESCRIPTION
Adds Dependabot for automated weekly dependency updates (Gradle + GitHub Actions) and a basic SECURITY.md policy.