### PR TITLE
[CI]: Add Desktop CI for :desktop, :core desktopTest and :cli

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -16,7 +16,7 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build:
+  desktop:
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -1,0 +1,44 @@
+# Desktop/CLI counterpart to android.yml.
+#
+# android.yml runs `assembleDebug testDebugUnitTest :app:lintDebug`, which only
+# reaches :core's androidTarget. That leaves :desktop, :cli and :core's
+# desktopTest source set uncompiled and unrun on every PR -- a green Android
+# check has never said anything about them. This job closes that gap.
+#
+# Kept as a separate workflow rather than a job in android.yml so the check
+# name stays distinct if it is ever made a required status check.
+name: Desktop CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      # :desktop is a single jvm("desktop") target, so compiling it on Linux
+      # covers the Kotlin/Compose surface; OS differences live behind
+      # OsBindings at runtime and are exercised by release.yml's per-OS jobs.
+      # :cli:build compiles and tests the CLI module, which is plain
+      # kotlin("jvm") and so has an ordinary `build` lifecycle task.
+      - name: Build and Test
+        run: ./gradlew :desktop:compileKotlinDesktop :core:desktopTest :cli:build


### PR DESCRIPTION
## Summary

Add `Desktop CI`, a PR-triggered workflow covering `:desktop`, `:core`'s desktop test source set, and `:cli`.

`android.yml` is currently the only workflow that runs on a PR, and it runs `assembleDebug testDebugUnitTest :app:lintDebug` — all of which stop at `:core`'s `androidTarget`. The consequence is that a green check on this repo says nothing about the desktop or CLI code:

- `:desktop` has never been compiled on a PR.
- `:cli` has never been compiled on a PR.
- `core/src/desktopTest` has never been run.
- `release.yml` is tag/`workflow_dispatch`-only, so it is never validated either.

## Why now

Two open PRs are affected by this blind spot:

- **#113** bumps `composeMaterial3Mp`, which `libs.versions.toml` deliberately holds off the `composeMultiplatform` track for the expressive APIs. It is consumed only by `:desktop`, and the PR passed CI without `:desktop` ever being built.
- **#92** adds 13 test files (5 under `core/src/desktopTest`, 8 under `cli/src/test`) that no current job would execute.

## Scope

One job on `ubuntu-latest`:

```
./gradlew :desktop:compileKotlinDesktop :core:desktopTest :cli:build
```

`:desktop` is a single `jvm("desktop")` target — OS differences are handled at runtime via `OsBindings`, and per-OS packaging is already exercised by `release.yml` — so one host covers the Kotlin/Compose surface without tripling CI minutes.

Kept as a separate workflow rather than a job inside `android.yml` so the check name stays distinct if it is ever promoted to a required status check.

## Verification

- Ran `./gradlew :desktop:compileKotlinDesktop :core:desktopTest :cli:build` on `main`: `BUILD SUCCESSFUL`, with `:desktop:compileKotlinDesktop` and `:cli:compileKotlin` executing. `:core:desktopTest` is `NO-SOURCE` on `main` today and starts doing real work once #92 lands.
- Workflow YAML parsed and asserted for triggers and run command.

