### PR TITLE
[Security]: Constrain jdom2 to 2.0.6.1 for GHSA-2363-cqg2-863c

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,19 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+
+// AGP pulls jdom2 in transitively through jetifier-processor. 2.0.6 parses XML
+// with external entities enabled (GHSA-2363-cqg2-863c, XXE). Nothing here feeds
+// it untrusted XML, and it never reaches a shipped artifact -- it is on the
+// build classpath only -- but the patched release is a drop-in, so there is no
+// reason to keep the vulnerable one around.
+buildscript {
+    dependencies {
+        constraints {
+            classpath("org.jdom:jdom2:2.0.6.1") {
+                because("GHSA-2363-cqg2-863c: XXE injection in jdom2 < 2.0.6.1")
+            }
+        }
+    }
+}
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false


### PR DESCRIPTION
Closes Dependabot alert #14 (high).

## What

`org.jdom:jdom2` reaches the build classpath transitively: AGP 9.4.0 -> `jetifier-processor:1.0.0-beta10` -> `jdom2:2.0.6`. That release parses XML with external entities enabled (GHSA-2363-cqg2-863c, XXE).

Since the version is chosen by AGP rather than by us, this pins it with a buildscript dependency constraint rather than a version-catalog bump.

## Scope

Build classpath only -- jdom2 is never packaged into the APK, the desktop image, or the CLI bundle, and nothing in this project feeds it untrusted XML. The patched release is a drop-in, so there is no reason to keep the vulnerable one on the classpath.

## Verification

- `./gradlew buildEnvironment` shows `org.jdom:jdom2:2.0.6 -> 2.0.6.1`
- `./gradlew :app:assembleDebug --dry-run` configures cleanly
- CI covers the full Android and desktop builds

Sibling PRs constrain the other flagged transitives in the same block; whichever merges second will need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)