### PR TITLE
[Security]: Constrain jose4j to 0.9.6 for GHSA-3677-xxcr-wjqv

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,18 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+
+// AGP pulls jose4j in transitively through its Google auth stack. 0.9.5
+// decompresses JWE payloads without an output bound, so a crafted token can
+// exhaust the heap (GHSA-3677-xxcr-wjqv). Build classpath only -- it never
+// reaches a shipped artifact -- but the patched release is a drop-in.
+buildscript {
+    dependencies {
+        constraints {
+            classpath("org.bitbucket.b_c:jose4j:0.9.6") {
+                because("GHSA-3677-xxcr-wjqv: DoS via compressed JWE content in jose4j < 0.9.6")
+            }
+        }
+    }
+}
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,27 +1,23 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
-<<<<<<< HEAD
-// AGP pulls jose4j in transitively through its Google auth stack. 0.9.5
-// decompresses JWE payloads without an output bound, so a crafted token can
-// exhaust the heap (GHSA-3677-xxcr-wjqv). Build classpath only -- it never
-// reaches a shipped artifact -- but the patched release is a drop-in.
+// AGP and the Kotlin Gradle plugin pull these in transitively, so the versions
+// are theirs rather than ours and a version-catalog bump cannot reach them.
+// Every one of them is on the build classpath only -- none is packaged into the
+// APK, the desktop image or the CLI bundle -- but each patched release is a
+// drop-in, so there is no reason to keep a flagged version around.
 buildscript {
     dependencies {
         constraints {
-            classpath("org.bitbucket.b_c:jose4j:0.9.6") {
-                because("GHSA-3677-xxcr-wjqv: DoS via compressed JWE content in jose4j < 0.9.6")
-=======
-// AGP pulls jdom2 in transitively through jetifier-processor. 2.0.6 parses XML
-// with external entities enabled (GHSA-2363-cqg2-863c, XXE). Nothing here feeds
-// it untrusted XML, and it never reaches a shipped artifact -- it is on the
-// build classpath only -- but the patched release is a drop-in, so there is no
-// reason to keep the vulnerable one around.
-buildscript {
-    dependencies {
-        constraints {
+            // 2.0.6 parses XML with external entities enabled. Reached through
+            // AGP -> jetifier-processor; nothing here feeds it untrusted XML.
             classpath("org.jdom:jdom2:2.0.6.1") {
                 because("GHSA-2363-cqg2-863c: XXE injection in jdom2 < 2.0.6.1")
->>>>>>> origin/main
+            }
+            // 0.9.5 decompresses JWE payloads without an output bound, so a
+            // crafted token can exhaust the heap. Reached through AGP's Google
+            // auth stack; nothing here processes JWEs.
+            classpath("org.bitbucket.b_c:jose4j:0.9.6") {
+                because("GHSA-3677-xxcr-wjqv: DoS via compressed JWE content in jose4j < 0.9.6")
             }
         }
     }


### PR DESCRIPTION
Closes Dependabot alert #16 (high).

## What

`org.bitbucket.b_c:jose4j` reaches the build classpath through AGP 9.4.0's Google auth stack. 0.9.5 decompresses JWE payloads without an output bound, so a crafted token can exhaust the heap (GHSA-3677-xxcr-wjqv).

Since the version is chosen by AGP (and, for Bouncy Castle, the Kotlin Gradle plugin) rather than by us, this pins it with a buildscript dependency constraint rather than a version-catalog bump.

## Scope

Build classpath only -- this artifact is never packaged into the APK, the desktop image, or the CLI bundle. Nothing in this project processes JWEs.

## Verification

- `./gradlew buildEnvironment` shows `org.bitbucket.b_c:jose4j:0.9.5 -> 0.9.6`
- `./gradlew :app:assembleDebug --dry-run` configures cleanly
- CI covers the full Android and desktop builds

Sibling PRs constrain the other flagged transitives in the same block; whichever merges second will need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)