### PR TITLE
[Security]: Constrain bcprov-jdk18on to 1.84 for GHSA-c3fc-8qff-9hwx

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,18 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+
+// Bouncy Castle arrives transitively from both AGP and the Kotlin Gradle
+// plugin. 1.80.2 does not escape values used to build LDAP filters
+// (GHSA-c3fc-8qff-9hwx). Build classpath only, and nothing here performs LDAP
+// lookups, but the patched release is a drop-in.
+buildscript {
+    dependencies {
+        constraints {
+            classpath("org.bouncycastle:bcprov-jdk18on:1.84") {
+                because("GHSA-c3fc-8qff-9hwx: LDAP injection in bcprov-jdk18on < 1.84")
+            }
+        }
+    }
+}
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false


### PR DESCRIPTION
Closes Dependabot alert #20 (moderate).

## What

`org.bouncycastle:bcprov-jdk18on` arrives transitively from both AGP 9.4.0 and the Kotlin Gradle plugin. 1.80.2 does not escape values used to build LDAP filters (GHSA-c3fc-8qff-9hwx).

Since the version is chosen by AGP (and, for Bouncy Castle, the Kotlin Gradle plugin) rather than by us, this pins it with a buildscript dependency constraint rather than a version-catalog bump.

## Scope

Build classpath only -- this artifact is never packaged into the APK, the desktop image, or the CLI bundle. Nothing here performs LDAP lookups.

## Verification

- `./gradlew buildEnvironment` shows `org.bouncycastle:bcprov-jdk18on:1.80.2 -> 1.84`
- `./gradlew :app:assembleDebug --dry-run` configures cleanly
- CI covers the full Android and desktop builds

Sibling PRs constrain the other flagged transitives in the same block; whichever merges second will need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)