### PR TITLE
[Security]: Constrain bcpkix-jdk18on to 1.84 for GHSA-wg6q-6289-32hp

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,18 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+
+// bcpkix ships alongside bcprov on the build classpath, pulled by AGP and the
+// Kotlin Gradle plugin. Modules in 1.80.2 still use a broken cryptographic
+// algorithm (GHSA-wg6q-6289-32hp). Build classpath only, but the patched
+// release is a drop-in.
+buildscript {
+    dependencies {
+        constraints {
+            classpath("org.bouncycastle:bcpkix-jdk18on:1.84") {
+                because("GHSA-wg6q-6289-32hp: broken cryptographic algorithm in bcpkix-jdk18on < 1.84")
+            }
+        }
+    }
+}
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false


### PR DESCRIPTION
Closes Dependabot alert #19 (moderate).

## What

`org.bouncycastle:bcpkix-jdk18on` ships alongside bcprov on the build classpath, pulled by AGP 9.4.0 and the Kotlin Gradle plugin. Modules in 1.80.2 still use a broken cryptographic algorithm (GHSA-wg6q-6289-32hp).

Since the version is chosen by AGP (and, for Bouncy Castle, the Kotlin Gradle plugin) rather than by us, this pins it with a buildscript dependency constraint rather than a version-catalog bump.

## Scope

Build classpath only -- this artifact is never packaged into the APK, the desktop image, or the CLI bundle. The affected modules are not exercised by this build.

## Verification

- `./gradlew buildEnvironment` shows `org.bouncycastle:bcpkix-jdk18on:1.80.2 -> 1.84`
- `./gradlew :app:assembleDebug --dry-run` configures cleanly
- CI covers the full Android and desktop builds

Sibling PRs constrain the other flagged transitives in the same block; whichever merges second will need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)