### PR TITLE
[Security]: Constrain commons-lang3 to 3.18.0 for GHSA-j288-q9x7-2f5v

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,18 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+
+// commons-lang3 reaches the build classpath through AGP. 3.16.0 recurses
+// without a depth bound on long inputs, so a large string can overflow the
+// stack (GHSA-j288-q9x7-2f5v). Build classpath only, but the patched release
+// is a drop-in.
+buildscript {
+    dependencies {
+        constraints {
+            classpath("org.apache.commons:commons-lang3:3.18.0") {
+                because("GHSA-j288-q9x7-2f5v: uncontrolled recursion in commons-lang3 < 3.18.0")
+            }
+        }
+    }
+}
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false


### PR DESCRIPTION
Closes Dependabot alert #51 (moderate).

## What

`org.apache.commons:commons-lang3` reaches the build classpath through AGP 9.4.0. 3.16.0 recurses without a depth bound on long inputs, so a large string can overflow the stack (GHSA-j288-q9x7-2f5v).

Since the version is chosen by AGP (and, for Bouncy Castle, the Kotlin Gradle plugin) rather than by us, this pins it with a buildscript dependency constraint rather than a version-catalog bump.

## Scope

Build classpath only -- this artifact is never packaged into the APK, the desktop image, or the CLI bundle. Only AGP feeds it, and never with attacker-controlled input.

## Verification

- `./gradlew buildEnvironment` shows `org.apache.commons:commons-lang3:3.16.0 -> 3.18.0`
- `./gradlew :app:assembleDebug --dry-run` configures cleanly
- CI covers the full Android and desktop builds

Sibling PRs constrain the other flagged transitives in the same block; whichever merges second will need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)