### PR TITLE
[Security]: Constrain httpclient to 4.5.14 for GHSA-7r82-7xv7-xcpj

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,19 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+
+// AGP declares httpclient 4.5.6, which is vulnerable to XSS in its error
+// responses (GHSA-7r82-7xv7-xcpj, fixed in 4.5.13). Conflict resolution
+// already lands the build classpath on 4.5.14, so this constraint changes
+// nothing today -- it states the safe floor rather than leaving it incidental
+// to whichever AGP version happens to win.
+buildscript {
+    dependencies {
+        constraints {
+            classpath("org.apache.httpcomponents:httpclient:4.5.14") {
+                because("GHSA-7r82-7xv7-xcpj: cross-site scripting in httpclient < 4.5.13")
+            }
+        }
+    }
+}
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false


### PR DESCRIPTION
Closes Dependabot alert #50 (moderate).

## What

AGP 9.4.0 declares `org.apache.httpcomponents:httpclient` 4.5.6, which is vulnerable to XSS in its error responses (GHSA-7r82-7xv7-xcpj, fixed in 4.5.13). **Conflict resolution already lands the build classpath on 4.5.14**, so this constraint changes nothing today -- it states the safe floor explicitly rather than leaving it incidental to whichever AGP version happens to win.

Since the version is chosen by AGP (and, for Bouncy Castle, the Kotlin Gradle plugin) rather than by us, this pins it with a buildscript dependency constraint rather than a version-catalog bump.

## Scope

Build classpath only -- this artifact is never packaged into the APK, the desktop image, or the CLI bundle. The alert was already satisfied by resolution; this makes that intentional.

## Verification

- `./gradlew buildEnvironment` shows `org.apache.httpcomponents:httpclient:4.5.6 -> 4.5.14`
- `./gradlew :app:assembleDebug --dry-run` configures cleanly
- CI covers the full Android and desktop builds

Sibling PRs constrain the other flagged transitives in the same block; whichever merges second will need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)