### PR TITLE
[Settings]: Write settings atomically instead of from a background writer

### DIFF
--- a/core/src/desktopMain/kotlin/com/vinnovateit/latch/core/runtime/DesktopEngineRuntime.kt
+++ b/core/src/desktopMain/kotlin/com/vinnovateit/latch/core/runtime/DesktopEngineRuntime.kt
@@ -32,8 +32,9 @@ class DesktopEngineRuntime private constructor(
     suspend fun close() {
         if (!closed.compareAndSet(false, true)) return
         if (started.get()) engine.submitAndAwait(LatchCommand.Shutdown, ENGINE_SHUTDOWN_TIMEOUT_MS)
-        // Before the process can exit: a one-shot CLI writes a setting and is
-        // gone milliseconds later, well before a deferred write would land.
+        // No-op for stores that already write synchronously; the contract
+        // exists for any store that defers, since a one-shot CLI exits
+        // milliseconds after writing a setting.
         platform.settingsStore.flush()
         database.close()
     }

--- a/core/src/desktopMain/kotlin/com/vinnovateit/latch/desktop/platform/JsonKeyValueStore.kt
+++ b/core/src/desktopMain/kotlin/com/vinnovateit/latch/desktop/platform/JsonKeyValueStore.kt
@@ -9,12 +9,9 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.buildJsonObject
 import java.io.File
-
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.channels.*
+import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 
 /**
  * Settings persistence as a plain JSON file.
@@ -42,27 +39,46 @@ class JsonKeyValueStore(
         data class StrSet(val value: Set<String>) : JsonPrimitiveOrArray
     }
 
-    private val scope        = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    private val writeChannel = Channel<JsonObject>(10)
-    // Channel's buffer has size 10.
-
-    /** Serialises the two write paths -- the writer coroutine and [flush]. */
+    /** Serialises writers against each other. */
     private val writeLock = Any()
 
     init {
         load()
-        // Load file then launch writer coroutine.
-        scope.launch {
-            for (jsonObj in writeChannel) {
-                write(jsonObj)
-                logger.d(TAG, "Saved settings to file.")
-            }
-        }
     }
 
+    /**
+     * Writes the settings file whole, on the calling thread.
+     *
+     * Deliberately not deferred to a coroutine. A background writer meant a
+     * one-shot `latch-cli --settings set ...` exited before its write ran, and
+     * it left a window where the file was truncated mid-rewrite -- a reader
+     * arriving then (another Latch process, or the next store instance) parsed
+     * nothing and silently fell back to defaults. The file is well under a
+     * kilobyte and only written on an explicit settings change, so writing it
+     * inline costs nothing worth deferring.
+     *
+     * The temp-file-plus-move keeps that window closed for readers: they see
+     * either the previous file or the new one, never a half-written one.
+     */
     private fun write(obj: JsonObject) = synchronized(writeLock) {
         file.parentFile?.mkdirs()
-        file.writeText(json.encodeToString(JsonObject.serializer(), obj))
+        val temporary = Files.createTempFile(file.parentFile.toPath(), file.name, ".tmp")
+        try {
+            Files.writeString(temporary, json.encodeToString(JsonObject.serializer(), obj))
+            try {
+                Files.move(
+                    temporary,
+                    file.toPath(),
+                    StandardCopyOption.ATOMIC_MOVE,
+                    StandardCopyOption.REPLACE_EXISTING,
+                )
+            } catch (_: AtomicMoveNotSupportedException) {
+                Files.move(temporary, file.toPath(), StandardCopyOption.REPLACE_EXISTING)
+            }
+        } finally {
+            Files.deleteIfExists(temporary)
+        }
+        logger.d(TAG, "Saved settings to file.")
     }
 
     private fun load() {
@@ -111,29 +127,9 @@ class JsonKeyValueStore(
 
     private fun persist() {
         try {
-            if (!writeChannel.trySend(snapshot()).isSuccess) {
-                throw Exception("Write channel is currently full.")
-            }
-        } catch (e: Throwable) {
-            logger.e(TAG, "Failed to persist settings", e)
-        }
-    }
-
-    /**
-     * Writes the current settings on the calling thread.
-     *
-     * The writer coroutine above is right for the desktop app, which outlives
-     * any queued write by hours. It is wrong for a one-shot `latch-cli
-     * --settings set ...`, which returns success and exits before the
-     * coroutine is ever scheduled -- the setting was silently lost. Called from
-     * DesktopEngineRuntime.close(), so every owner lands its writes on the way
-     * out.
-     */
-    override fun flush() {
-        try {
             write(snapshot())
         } catch (e: Throwable) {
-            logger.e(TAG, "Failed to flush settings", e)
+            logger.e(TAG, "Failed to persist settings", e)
         }
     }
 

--- a/core/src/desktopTest/kotlin/com/vinnovateit/latch/desktop/platform/JsonKeyValueStoreTest.kt
+++ b/core/src/desktopTest/kotlin/com/vinnovateit/latch/desktop/platform/JsonKeyValueStoreTest.kt
@@ -1,6 +1,7 @@
 package com.vinnovateit.latch.desktop.platform
 
 import com.vinnovateit.latch.core.platform.NoOpLogger
+import kotlin.concurrent.thread
 import kotlin.io.path.createTempDirectory
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -8,23 +9,51 @@ import kotlin.test.assertTrue
 
 class JsonKeyValueStoreTest {
     @Test
-    fun `flush lands writes a short-lived process would otherwise lose`() {
+    fun `a write is on disk by the time it returns`() = withStoreFile { file ->
+        val store = JsonKeyValueStore(file, NoOpLogger)
+
+        store.putStringSet("allowed_ssids", setOf("G-VIT"))
+        store.putBoolean("auto_login", false)
+
+        assertTrue(file.exists(), "settings were not on disk when the write returned")
+        // A fresh store is what the next `latch-cli` invocation sees.
+        val reopened = JsonKeyValueStore(file, NoOpLogger)
+        assertEquals(setOf("G-VIT"), reopened.getStringSet("allowed_ssids", setOf("VIT")))
+        assertEquals(false, reopened.getBoolean("auto_login", true))
+    }
+
+    /**
+     * The store used to rewrite the file in place from a background coroutine,
+     * so a reader arriving mid-write parsed a truncated file, swallowed the
+     * error and silently fell back to defaults -- losing the user's settings
+     * for that process. Writes now land through a temp file and an atomic move,
+     * so a reader sees either the old file or the new one.
+     */
+    @Test
+    fun `a reader never sees a half-written file`() = withStoreFile { file ->
+        val store = JsonKeyValueStore(file, NoOpLogger)
+        store.putString("theme", "value-0")
+
+        val failures = mutableListOf<String>()
+        val writer = thread {
+            repeat(400) { store.putString("theme", "value-$it") }
+        }
+        val reader = thread {
+            repeat(400) {
+                val seen = JsonKeyValueStore(file, NoOpLogger).getString("theme", "MISSING")
+                if (!seen.startsWith("value-")) synchronized(failures) { failures += seen }
+            }
+        }
+        writer.join()
+        reader.join()
+
+        assertEquals(emptyList(), failures, "reader observed a torn or missing settings file")
+    }
+
+    private fun withStoreFile(block: (java.io.File) -> Unit) {
         val directory = createTempDirectory("latch-settings-").toFile()
-        val file = directory.resolve("settings.json")
         try {
-            val store = JsonKeyValueStore(file, NoOpLogger)
-
-            store.putStringSet("allowed_ssids", setOf("G-VIT"))
-            store.putBoolean("auto_login", false)
-            // Stands in for the process exiting: no scheduling window is given
-            // to the background writer.
-            store.flush()
-
-            assertTrue(file.exists(), "settings were not on disk when flush() returned")
-            // A fresh store is what the next `latch-cli` invocation sees.
-            val reopened = JsonKeyValueStore(file, NoOpLogger)
-            assertEquals(setOf("G-VIT"), reopened.getStringSet("allowed_ssids", setOf("VIT")))
-            assertEquals(false, reopened.getBoolean("auto_login", true))
+            block(directory.resolve("settings.json"))
         } finally {
             directory.deleteRecursively()
         }


### PR DESCRIPTION
Fixes the intermittent JsonKeyValueStoreTest failure seen on #117. The store rewrote settings.json in place from a background coroutine, so a reader arriving mid-write parsed a truncated file, swallowed the error and fell back to defaults. Writes now go through a temp file and an atomic move, on the calling thread. New test hammers a parallel reader and writer; both new tests fail against the old implementation.