### PR TITLE
[Tooling]: Pin the Java toolchain and add contribution docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,28 @@
+# Latch Code of Conduct
+
+## Our commitment
+
+VinnovateIT's Latch community is committed to a welcoming, harassment-free environment for everyone, regardless of identity, background, experience, or ability.
+
+## Expected behavior
+
+- Be respectful, constructive, and patient.
+- Critique ideas and code, not people.
+- Respect privacy, boundaries, and differing levels of experience.
+- Accept responsibility, apologize when appropriate, and learn from mistakes.
+
+Harassment, discrimination, threats, sexualized attention, deliberate intimidation, doxxing, and sustained disruptive behavior are unacceptable.
+
+## Scope
+
+This policy applies in repository spaces, project communications, VinnovateIT community events, and public situations where someone is representing the project or organization.
+
+## Private reporting and enforcement
+
+Report concerns privately through an established VinnovateIT or repository-maintainer contact channel. Do not disclose incident details in a public issue or discussion. If no private route is known, ask a maintainer for a private contact method without describing the incident publicly.
+
+Maintainers will acknowledge reports, protect confidentiality as far as reasonably possible, avoid conflicts of interest, and respond proportionately. Responses may range from a private correction or warning to temporary restrictions or permanent removal from project spaces. Retaliation against reporters or participants in a review is prohibited.
+
+## Attribution
+
+This policy is informed by the [Contributor Covenant, version 3.0](https://www.contributor-covenant.org/version/3/0/code_of_conduct/), available under the Creative Commons Attribution-ShareAlike 4.0 license.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing to Latch
+
+Latch spans Android, desktop, CLI, and shared Kotlin modules. Keep cross-platform behavior in `core/` and platform-specific integration in its owning module.
+
+## Development setup
+
+Use JDK 21 through the repository `mise.toml`, the checked-in Gradle wrapper, Android Studio, and Android SDK Platform 37:
+
+```sh
+mise current
+./gradlew assembleDebug testDebugUnitTest :app:lintDebug
+```
+
+Run the desktop application with:
+
+```sh
+./gradlew :desktop:run
+```
+
+The Gradle project still configures the Android module when building desktop targets, so the Android SDK must be available.
+
+## Change guidelines
+
+- Preserve the JVM targets declared by each module; the JDK used to run Gradle is not permission to raise them.
+- Put shared network/authentication behavior in `core/` and add tests at that boundary.
+- Keep UI and packaging changes within `app/` or `desktop/` as appropriate.
+- Never commit VIT credentials, captured portal sessions, signing files, or local Android SDK paths.
+
+## Pull requests
+
+Include the CI-equivalent Gradle result, identify every affected platform, and attach screenshots for visible UI changes. Document any portal-flow assumption that may require campus-network verification.

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+java = "temurin-21.0.12+101.0.LTS"


### PR DESCRIPTION
### `[Tooling]: Pin Java toolchain`

Adds `mise.toml` pinning `java = "temurin-21.0.12+101.0.LTS"`.

The repository has had no toolchain pin, so every contributor's JDK came from whatever their global config or `PATH` happened to provide. CI already standardises on Temurin 21 (`actions/setup-java@v4` in `android.yml`, `desktop.yml` and `release.yml`); this makes a local checkout match without relying on a developer's global mise config.

Verified locally — with the file in place, `mise config ls` reports the repository config alongside the global one and `mise exec -- java -version` resolves to Temurin 21.0.12.

### `[Docs]: Add community contribution guidance`

Adds `CONTRIBUTING.md` (module boundaries, development setup, JVM-target and credential-hygiene rules, PR expectations) and `CODE_OF_CONDUCT.md` (Contributor Covenant 3.0, with private reporting through VinnovateIT maintainer channels).

`SECURITY.md` and `README.md` are already on `main`; these are the two remaining standard community health files GitHub looks for.

### Notes

No build files are touched — Gradle does not read `mise.toml`, so this cannot affect CI behaviour or the resolved dependency graph.