### PR TITLE
fix(android): fix conditional compose state collection and drop unused deps

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.compose)
-    id("com.google.devtools.ksp")
     id("org.jetbrains.kotlin.plugin.serialization")
 }
 
@@ -57,7 +56,6 @@ kotlin {
 
 dependencies {
     implementation(project(":core"))
-    implementation(libs.androidx.compose.material.core)
 
     // Core & Lifecycle
     implementation(libs.androidx.core.ktx)

--- a/app/src/main/java/com/vinnovateit/latch/navigation/LatchNavGraph.kt
+++ b/app/src/main/java/com/vinnovateit/latch/navigation/LatchNavGraph.kt
@@ -73,16 +73,16 @@ fun LatchNavGraph(
     wifiStatusViewModel: WiFiStatusViewModel,
     startDestination: String
 ) {
+    val statsViewModel: StatsViewModel = viewModel()
+
     val homeContent: @Composable () -> Unit = {
-        val statsViewModel: StatsViewModel = viewModel()
         val isConnected by wifiStatusViewModel.isConnected.collectAsStateWithLifecycle()
         val liveStatus by statsViewModel.liveStatus.collectAsStateWithLifecycle()
         val connectionStatus by wifiStatusViewModel.connectionStatus.collectAsStateWithLifecycle()
         val speedUnits by SettingsManager.speedUnits.collectAsStateWithLifecycle()
+        val sessionToShow by statsViewModel.sessionToShow.collectAsStateWithLifecycle()
 
-        val sessionForHomeScreen = if (isConnected && liveStatus != null) {
-            statsViewModel.sessionToShow.collectAsStateWithLifecycle().value
-        } else null
+        val sessionForHomeScreen = if (isConnected && liveStatus != null) sessionToShow else null
 
         Surface(modifier = Modifier.fillMaxSize()) {
             HomeScreen(
@@ -183,7 +183,6 @@ fun LatchNavGraph(
 
         // Stats
         composable(LatchRoutes.STATS) {
-            val statsViewModel: StatsViewModel = viewModel()
             val coroutineScope = rememberCoroutineScope()
             val context = LocalContext.current
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,7 +43,6 @@ sqliteBundled = "2.7.0"
 oshi = "7.6.1"
 jna = "5.19.1"
 slf4jSimple = "2.0.18"
-composeMaterialCore = "1.6.2"
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -129,4 +128,3 @@ oshi-core = { module = "com.github.oshi:oshi-core", version.ref = "oshi" }
 jna = { module = "net.java.dev.jna:jna", version.ref = "jna" }
 jna-platform = { module = "net.java.dev.jna:jna-platform", version.ref = "jna" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4jSimple" }
-androidx-compose-material-core = { group = "androidx.wear.compose", name = "compose-material-core", version.ref = "composeMaterialCore" }


### PR DESCRIPTION
## Summary

Fixes two issues in the Android module:

1. In `LatchNavGraph.kt`, `collectAsStateWithLifecycle()` was called conditionally inside an `if` block. In Compose, calling composable functions conditionally causes slot table mismatches and resets state when connection status toggles. This change hoists the collection outside the conditional and hoists `StatsViewModel` to the graph root so slide-back background containers do not allocate duplicate ViewModels.
2. Removes `id("com.google.devtools.ksp")` from `:app` (Room compiler now runs in `:core`) and removes the unused `androidx.wear.compose:compose-material-core` dependency.

## Changes

- Hoist `sessionToShow` collection in `homeContent` to keep Compose slot table stable.
- Scope `StatsViewModel` at `LatchNavGraph` root to prevent redundant instances in back containers.
- Remove dead KSP plugin from `app/build.gradle.kts`.
- Delete unused Wear OS Compose dependency from `libs.versions.toml` and `app/build.gradle.kts`.

## Verification

- `./gradlew :app:compileDebugKotlin` passed cleanly.