### PR TITLE
fix(desktop): decouple wifi connectivity checks from scraped ssid

### DIFF
--- a/core/src/desktopMain/kotlin/com/vinnovateit/latch/desktop/platform/linux/LinuxWifiPlatform.kt
+++ b/core/src/desktopMain/kotlin/com/vinnovateit/latch/desktop/platform/linux/LinuxWifiPlatform.kt
@@ -88,11 +88,13 @@ class LinuxWifiPlatform(private val logger: Logger) : WifiPlatform {
         val wifiEnabled = checkWifiEnabled()
         val (iface, ssid) = resolveConnectedWifi()
         val gateway = resolveGateway(iface)
+        val hasIp = iface?.let { hasIpv4(it) } ?: false
+        val isConnected = hasIp || !gateway.isNullOrEmpty() || !ssid.isNullOrEmpty()
 
         val snap = WifiSnapshot(
             interfaceName = iface,
             wifiEnabled = wifiEnabled,
-            connected = !ssid.isNullOrEmpty(),
+            connected = isConnected,
             ssid = ssid?.takeIf { it.isNotEmpty() },
             gateway = gateway?.takeIf { it.isNotEmpty() },
         )
@@ -212,11 +214,27 @@ class LinuxWifiPlatform(private val logger: Logger) : WifiPlatform {
     private fun findFirstWirelessInterface(): String? {
         val netDir = File("/sys/class/net")
         if (netDir.exists()) {
-            return netDir.listFiles()
+            val sysfsName = netDir.listFiles()
                 ?.firstOrNull { File(it, "wireless").exists() || File(it, "phy80211").exists() }
                 ?.name
+            if (sysfsName != null) return sysfsName
         }
-        return null
+        return try {
+            java.net.NetworkInterface.getNetworkInterfaces()?.asSequence()?.firstOrNull { iface ->
+                !iface.isLoopback && iface.isUp && (iface.name.startsWith("wl") || iface.name.startsWith("wlan"))
+            }?.name
+        } catch (_: Throwable) {
+            null
+        }
+    }
+
+    private fun hasIpv4(ifaceName: String): Boolean = try {
+        val nif = java.net.NetworkInterface.getByName(ifaceName)
+        nif != null && nif.isUp && nif.inetAddresses.asSequence().any {
+            it is java.net.Inet4Address && !it.isLoopbackAddress && !it.isLinkLocalAddress
+        }
+    } catch (_: Throwable) {
+        false
     }
 
     private fun resolveGateway(iface: String?): String? {
@@ -306,8 +324,8 @@ class LinuxWifiPlatform(private val logger: Logger) : WifiPlatform {
 
     override val events: Flow<WifiEvent> = flow {
         val seed = snapshot()
-        var lastKey = if (seed.connected && seed.ssid != null && seed.interfaceName != null) {
-            "${seed.interfaceName}::${seed.ssid}"
+        var lastKey = if (seed.connected && seed.interfaceName != null) {
+            "${seed.interfaceName}::${seed.ssid ?: "unknown"}"
         } else {
             null
         }
@@ -315,8 +333,8 @@ class LinuxWifiPlatform(private val logger: Logger) : WifiPlatform {
         while (true) {
             invalidate()
             val snap = snapshot()
-            val key = if (snap.connected && snap.ssid != null && snap.interfaceName != null) {
-                "${snap.interfaceName}::${snap.ssid}"
+            val key = if (snap.connected && snap.interfaceName != null) {
+                "${snap.interfaceName}::${snap.ssid ?: "unknown"}"
             } else {
                 null
             }

--- a/core/src/desktopMain/kotlin/com/vinnovateit/latch/desktop/platform/windows/WindowsWifiPlatform.kt
+++ b/core/src/desktopMain/kotlin/com/vinnovateit/latch/desktop/platform/windows/WindowsWifiPlatform.kt
@@ -232,7 +232,7 @@ class WindowsWifiPlatform(private val logger: Logger) : WifiPlatform {
 
     override fun isConnectedToWifi(): Boolean {
         val snap = snapshot()
-        return snap.adapterUp && snap.ssid != null
+        return snap.adapterUp
     }
 
     override fun currentSsid(): String? = snapshot().ssid
@@ -259,16 +259,16 @@ class WindowsWifiPlatform(private val logger: Logger) : WifiPlatform {
 
     override val events: Flow<WifiEvent> = flow {
         val seed = snapshot()
-        var lastKey = if (seed.adapterUp && seed.ssid != null) {
-            "${seed.adapterName}::${seed.ssid}"
+        var lastKey = if (seed.adapterUp && seed.adapterName != null) {
+            "${seed.adapterName}::${seed.ssid ?: "unknown"}"
         } else {
             null
         }
 
         while (true) {
             val snap = snapshot()
-            val key = if (snap.adapterUp && snap.ssid != null) {
-                "${snap.adapterName}::${snap.ssid}"
+            val key = if (snap.adapterUp && snap.adapterName != null) {
+                "${snap.adapterName}::${snap.ssid ?: "unknown"}"
             } else {
                 null
             }


### PR DESCRIPTION
## Summary
Decouples Wi-Fi link and event detection from scraped SSID strings on Linux and Windows platforms to resolve frequent desktop auto-login drops.

## Motivation & Changes
Previously, desktop implementations treated an interface as disconnected (`connected = false` / `activeHandle() = null`) if external system utilities (`nmcli`, `iwgetid`, `netsh`, PowerShell) failed to extract or parse an exact SSID name. This caused `LatchEngine` to immediately bail with `NotOnWifi` even when properly associated with a valid IPv4 address and default gateway.

- **Linux (`LinuxWifiPlatform`)**:
  - Connection status is now evaluated based on IPv4 address assignment or gateway reachability in addition to SSID presence.
  - Added JVM `NetworkInterface` fallback when scanning for wireless interfaces if sysfs entries are inaccessible.
  - Emits `WifiEvent.Available` when an interface is connected regardless of whether the SSID string could be resolved.

- **Windows (`WindowsWifiPlatform`)**:
  - `isConnectedToWifi()` now relies directly on adapter link state (`adapterUp`).
  - Emits `WifiEvent.Available` based on adapter up-state without requiring a non-null SSID string.

Network target validation remains gated by `isVitCampusSsid()` and captive portal probe resolution in `LatchEngine`.

## Verification
- `./gradlew :core:compileKotlinDesktop :desktop:compileKotlinDesktop :cli:build` passed.
- `./gradlew :core:desktopTest` passed.
- Built and validated RPM packaging via `./gradlew :desktop:packageRpm`.