### PR TITLE
[Release]: Bump version to 1.3.9

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-latchVersion=1.3.8
+latchVersion=1.3.9
 # Enables namespacing of each library's R class so that its R class includes only the
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library


### PR DESCRIPTION
Bumps latchVersion from 1.3.8 to 1.3.9 for urgent wifi and Compose fixes.