### PR TITLE
[Build]: Substitute latchVersion into the packaged version resource

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -74,3 +74,23 @@ dependencies {
     add("kspDesktop", libs.room.compiler.desktop)
     add("kspAndroid", libs.room.compiler.desktop)
 }
+
+// latch-version.properties is checked in as `version=${latchVersion}` and is the
+// only place :cli's --version, DesktopPlatformServices.versionName and the
+// GithubUpdater's "am I out of date" comparison get the version from. Nothing
+// substituted that token, so every desktop and CLI build shipped the literal
+// string. Scoped by filesMatching because expand() runs a Groovy template over
+// whatever it matches, and declared as an input so a latchVersion bump
+// invalidates the task instead of reusing a stale processed resource.
+tasks.named<ProcessResources>("desktopProcessResources") {
+    inputs.property("latchVersion", latchVersion)
+    filesMatching("latch-version.properties") {
+        expand("latchVersion" to latchVersion)
+    }
+}
+
+// Lets the desktopTest source set assert the packaged resource against the
+// gradle.properties value rather than a hardcoded copy of it.
+tasks.named<Test>("desktopTest") {
+    systemProperty("latchVersion", latchVersion)
+}

--- a/core/src/desktopTest/kotlin/com/vinnovateit/latch/core/LatchCoreVersionTest.kt
+++ b/core/src/desktopTest/kotlin/com/vinnovateit/latch/core/LatchCoreVersionTest.kt
@@ -1,0 +1,26 @@
+package com.vinnovateit.latch.core
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class LatchCoreVersionTest {
+
+    // latch-version.properties is a template; if processResources stops
+    // substituting it, LatchCore.VERSION becomes the literal "${latchVersion}"
+    // and every artifact reports that as its version. That shipped once
+    // already -- the v1.3.9 release job caught it only at the packaged CLI
+    // smoke test, after the tag was pushed.
+    @Test
+    fun `version resource is substituted at build time`() {
+        val expected = checkNotNull(System.getProperty("latchVersion")) {
+            "desktopTest must be given the latchVersion system property"
+        }
+        assertEquals(expected, LatchCore.VERSION)
+    }
+
+    @Test
+    fun `version carries no unresolved template token`() {
+        assertFalse(LatchCore.VERSION.contains('$'), "unresolved token in ${LatchCore.VERSION}")
+    }
+}


### PR DESCRIPTION
Fixes the `v1.3.9` release failure ([run 34176818697](https://github.com/vinnovateit/latch/actions/runs/34176818697)). Both the Linux and Windows `Smoke-test bundled CLI` steps failed with:

```
latch-cli ${latchVersion}
Unexpected CLI version output: latch-cli ${latchVersion}
```

### Cause

`core/src/desktopMain/resources/latch-version.properties` is checked in as a template:

```properties
version=${latchVersion}
```

`core/build.gradle.kts` imported `ProcessResources` and read the `latchVersion` gradle property, but never configured anything to substitute the token. The import and the `val` were the only trace of the intent. Both landed in 85c72e6 without the plumbing.

So `LatchCore.VERSION` has resolved to the literal string `${latchVersion}` in every desktop and CLI build since. This is not only a CI problem:

- `:cli --version` prints `latch-cli ${latchVersion}`.
- `DesktopPlatformServices.versionName` reports the same to the UI.
- `GithubUpdater` compares that literal against release tags when deciding whether the installed build is out of date.

Android CI and Desktop CI stayed green throughout because neither runs the packaged artifact; only the release job does, and only after the tag is pushed.

### Fix

Configure `desktopProcessResources` to expand the token, scoped by `filesMatching` since `expand()` runs a Groovy template over everything it matches, and declared via `inputs.property` so a `latchVersion` bump invalidates the task instead of reusing a stale processed resource.

### Regression test

`LatchCoreVersionTest` asserts `LatchCore.VERSION` equals the `latchVersion` gradle property (passed into `desktopTest` as a system property, so there is no hardcoded copy of the version) and that it contains no unresolved `$` token. This runs in Desktop CI and in the release job's `Verify shared runtime and CLI` step, which means the next occurrence is caught before a tag is pushed rather than after.

Confirmed non-vacuous: with the expansion block removed both tests fail (`ComparisonFailure`, `AssertionError`); with it in place both pass.

### Verification

- `./gradlew :core:desktopProcessResources` -> processed resource now reads `version=1.3.9` (previously `version=${latchVersion}`).
- `./gradlew :desktop:compileKotlinDesktop :core:desktopTest :cli:build` passes.
- `./gradlew :core:desktopTest :cli:test :desktop:smoke` (the release job's verification step) passes.
- `./gradlew :cli:packageCliTarGz` then the release job's exact smoke test:
  ```
  $ cli/build/cli-package/image/latch-cli/bin/latch-cli --version
  latch-cli 1.3.9
  ```

### After this merges

The `v1.3.9` tag points at a commit without the fix, and its release job never reached `Create GitHub release`, so no release was published. The tag needs to be repointed (or superseded by `v1.3.10`) to produce artifacts.