### PR TITLE
[Release]: Stage release artifacts flat so the release job can find them

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,16 +87,28 @@ jobs:
           cli/build/cli-package/image/latch-cli/bin/latch-cli --version
           test "$(cli/build/cli-package/image/latch-cli/bin/latch-cli --version)" = "latch-cli ${{ needs.prepare.outputs.version }}"
 
+      # upload-artifact roots an artifact at the least common ancestor of its
+      # path patterns. desktop/... and cli/... share only the repo root, so the
+      # artifact kept the full source paths and the release job found
+      # release-assets/cli/build/distributions/latch-cli-*.tar.gz rather than
+      # release-assets/latch-cli-*.tar.gz. Staging into one directory first
+      # makes the uploaded layout flat and independent of where Gradle wrote
+      # each file.
+      - name: Stage Linux artifacts
+        run: |
+          mkdir -p staging
+          cp desktop/build/distributions/*.tar.gz staging/
+          cp cli/build/distributions/*.tar.gz staging/
+          cp cli/build/distributions/*.deb staging/
+          cp cli/build/distributions/*.rpm staging/
+          ls -l staging
+
       - name: Upload Linux artifacts
         uses: actions/upload-artifact@v4
         with:
           name: linux-artifacts
           if-no-files-found: error
-          path: |
-            desktop/build/distributions/*.tar.gz
-            cli/build/distributions/*.tar.gz
-            cli/build/distributions/*.deb
-            cli/build/distributions/*.rpm
+          path: staging/*
 
   build-windows:
     name: Build Windows artifacts
@@ -125,14 +137,21 @@ jobs:
             throw "Unexpected CLI version output: $actual"
           }
 
+      # Flattened for the same reason as the Linux job above.
+      - name: Stage Windows artifacts
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path staging | Out-Null
+          Copy-Item desktop\build\compose\binaries\main-release\msi\*.msi staging\
+          Copy-Item cli\build\distributions\*.zip staging\
+          Get-ChildItem staging
+
       - name: Upload Windows artifacts
         uses: actions/upload-artifact@v4
         with:
           name: windows-artifacts
           if-no-files-found: error
-          path: |
-            desktop/build/compose/binaries/main-release/msi/*.msi
-            cli/build/distributions/*.zip
+          path: staging/*
 
   release:
     name: Create GitHub release
@@ -148,6 +167,12 @@ jobs:
           path: release-assets
           merge-multiple: true
 
+      # Every downstream step here addresses release-assets/<file> directly, so
+      # fail with the actual listing rather than a bare "must exist" if the
+      # layout ever drifts again.
+      - name: List downloaded artifacts
+        run: ls -lR release-assets
+
       - name: Generate package-manager manifests
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
@@ -161,7 +186,7 @@ jobs:
 
       - name: Generate checksums
         working-directory: release-assets
-        run: sha256sum * > SHA256SUMS
+        run: sha256sum -- * > SHA256SUMS
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
Second failure in the `v1.3.9` release, after the version-substitution fix in #131. The `Build Linux artifacts` and `Build Windows artifacts` jobs both pass now (including the CLI smoke test that failed before), and it gets as far as `Create GitHub release`, where `Generate package-manager manifests` fails ([run 34179124205](https://github.com/vinnovateit/latch/actions/runs/34179124205)):

```
Both release artifacts must exist
```

### Cause

`upload-artifact` roots an artifact at the **least common ancestor of its path patterns**. Both build jobs upload from two unrelated trees:

```yaml
path: |
  desktop/build/distributions/*.tar.gz
  cli/build/distributions/*.tar.gz
```

Their only common ancestor is the repo root, so the artifact preserves the full source paths. Confirmed by downloading `windows-artifacts` from the failed run:

```
<artifact-root>/cli/build/distributions/latch-cli-1.3.9-windows-x64.zip
<artifact-root>/desktop/build/compose/binaries/main-release/msi/Latch-1.3.9.msi
```

`merge-multiple: true` merges the two artifacts into one directory but does not flatten what is inside them, so the release job looked for `release-assets/latch-cli-1.3.9-linux-x64.tar.gz` while the file was actually at `release-assets/cli/build/distributions/latch-cli-1.3.9-linux-x64.tar.gz`. The filenames were always correct; only their depth was wrong.

Two later steps would have failed for the same reason: `sha256sum *` chokes on the leftover directories, and `files: release-assets/*` would have attached directories instead of archives.

### Fix

Each build job now copies its outputs into a single `staging/` directory and uploads `staging/*`, so the artifact layout is flat and no longer depends on where Gradle happened to write each file. Also added a `ls -lR release-assets` step in the release job so a future layout drift reports the actual tree instead of a bare "must exist", and fixed the `sha256sum` glob that `actionlint`/`shellcheck` flagged (SC2035).

### Verification

Downstream steps replayed locally against the **real artifacts** from the failed run (the Windows zip and MSI downloaded from `windows-artifacts`, the Linux tarball from a local `:cli:packageCliTarGz`), arranged flat as this change produces:

- `generate-cli-package-metadata.sh` succeeds and emits the AUR `PKGBUILD`/`.SRCINFO` and all three winget manifests.
- The generated `PKGBUILD` `sha256sums` matches the real tarball checksum (`b43b19cf…`).
- `zip -qr` of `package-metadata` succeeds.
- `sha256sum -- *` produces a `SHA256SUMS` that verifies clean against every asset.

`actionlint` (with shellcheck) is clean on the workflow.

None of this had run successfully before — the release job has never made it past artifact download.