### PR TITLE
[Release]: Stop publishing binaries for the unreleased CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,13 +100,12 @@ jobs:
       # release-assets/latch-cli-*.tar.gz. Staging into one directory first
       # makes the uploaded layout flat and independent of where Gradle wrote
       # each file.
+      # The CLI is built and smoke-tested above but deliberately not staged:
+      # it is unreleased, so releases carry the desktop app only.
       - name: Stage Linux artifacts
         run: |
           mkdir -p staging
           cp desktop/build/distributions/*.tar.gz staging/
-          cp cli/build/distributions/*.tar.gz staging/
-          cp cli/build/distributions/*.deb staging/
-          cp cli/build/distributions/*.rpm staging/
           ls -l staging
 
       - name: Upload Linux artifacts
@@ -143,13 +142,13 @@ jobs:
             throw "Unexpected CLI version output: $actual"
           }
 
-      # Flattened for the same reason as the Linux job above.
+      # Flattened for the same reason as the Linux job above, and likewise
+      # desktop-only while the CLI is unreleased.
       - name: Stage Windows artifacts
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force -Path staging | Out-Null
           Copy-Item desktop\build\compose\binaries\main-release\msi\*.msi staging\
-          Copy-Item cli\build\distributions\*.zip staging\
           Get-ChildItem staging
 
       - name: Upload Windows artifacts
@@ -178,17 +177,6 @@ jobs:
       # layout ever drifts again.
       - name: List downloaded artifacts
         run: ls -lR release-assets
-
-      - name: Generate package-manager manifests
-        env:
-          VERSION: ${{ needs.prepare.outputs.version }}
-        run: |
-          packaging/generate-cli-package-metadata.sh \
-            "$VERSION" \
-            "release-assets/latch-cli-$VERSION-linux-x64.tar.gz" \
-            "release-assets/latch-cli-$VERSION-windows-x64.zip" \
-            package-metadata
-          (cd package-metadata && zip -qr "../release-assets/latch-cli-$VERSION-package-metadata.zip" .)
 
       - name: Generate checksums
         working-directory: release-assets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,6 @@ before it builds anything if the section is missing.
 
 ### What's new
 
-- Latch now has a command line app, `latch-cli`, for Linux and Windows. Connect, disconnect, check status, or leave it running in the background.
-- Available as a `.deb`, an `.rpm`, a portable tarball, and a Windows ZIP, with AUR and winget metadata included in the assets.
-- Desktop and CLI share a single connection, so keeping both open no longer means two of them competing over the portal.
 - Credentials screen: fields focus themselves, and Enter moves to the next one.
 
 ### What's fixed
@@ -24,6 +21,8 @@ before it builds anything if the section is missing.
 - Updated bundled dependencies for six security advisories
 
 Download the compatible version for your machine from the assets below.
+
+The command line app is still unreleased and is not part of these downloads.
 
 ## 1.3.8
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Latch is a Kotlin application developed by VinnovateIT that automates the login 
 - Automatic detection of VIT hostel WiFi networks
 - Auto-login with securely stored credentials
 - Logging and display of network usage statistics
-- Standalone CLI for Linux terminals and Windows PowerShell
+- Standalone CLI for Linux terminals and Windows PowerShell (unreleased, build from source)
 
 ## Prerequisites
 
@@ -54,27 +54,39 @@ Before you start, make sure you have:
 
 2. Launch Latch from your application menu, or run `latch` in a terminal.
 
-   To install manually instead, download `latch-1.3.8-linux-x64.tar.gz` from the [latest release](https://github.com/vinnovateit/latch/releases/latest) and extract it.
+   To install manually instead, download the `latch-<version>-linux-x64.tar.gz` archive from the [latest release](https://github.com/vinnovateit/latch/releases/latest) and extract it.
 
 ### Command-line app
 
-`latch-cli` is a standalone application with its own trimmed Java runtime; Java does not need to be installed separately.
-
-On Debian or Ubuntu, download the `.deb` from the [latest release](https://github.com/vinnovateit/latch/releases/latest), then run:
+**`latch-cli` is not released yet.** Releases carry the desktop app only, so
+there is nothing to install with `apt`, `dnf`, winget, or the AUR at this point.
+Build it from a checkout instead:
 
 ```sh
-sudo apt install ./latch-cli_1.3.8_amd64.deb
+./gradlew :cli:packageCliTarGz   # portable tarball
+./gradlew :cli:packageCliDeb     # .deb
+./gradlew :cli:packageCliRpm     # .rpm
 ```
 
-RPM-based distributions can install the release package with `sudo dnf install ./latch-cli-*.rpm`. Arch users can install the `latch-cli-bin` AUR package after its release metadata is submitted. The portable `latch-cli-1.3.8-linux-x64.tar.gz` works without package-manager installation.
+On Windows:
 
-A hosted APT repository can be added later; the initial `.deb` is installed directly with `apt`. Flatpak is intentionally outside the CLI release scope because its sandbox and desktop-first distribution model do not fit a host-network command-line daemon.
+```powershell
+.\gradlew.bat :cli:packageCliZip
+```
 
-On Windows, install `VinnovateIT.LatchCLI` with winget after its manifest is accepted, or download and extract `latch-cli-1.3.8-windows-x64.zip`. The executable works directly from PowerShell:
+Packages land in `cli/build/distributions/`, and the runnable image is at
+`cli/build/cli-package/image/latch-cli/`. Each bundle carries its own trimmed
+Java runtime, so Java does not need to be installed separately. On Windows the
+executable works directly from PowerShell:
 
 ```powershell
 .\latch-cli.exe --status
 ```
+
+Packaging targets, a hosted APT repository, and the winget and AUR submissions
+are all deferred until the CLI is actually published. Flatpak is intentionally
+out of scope because its sandbox and desktop-first distribution model do not fit
+a host-network command-line daemon.
 
 Run `latch-cli` with no arguments the first time. It prompts for your VIT credentials, starts the auto-login daemon in the background, and enables per-user startup at login. On later runs, `latch-cli` prints its help menu.
 


### PR DESCRIPTION
`latch-cli` has never been released, but the v1.3.9 release attached five CLI assets (`.deb`, `.rpm`, portable tarball, Windows ZIP, package-manager metadata) and the README told people to install them from the latest release. The docs also cited 1.3.8 filenames, so even the names were wrong.

The published release has already been corrected: the five CLI assets are deleted and `SHA256SUMS` was reuploaded covering only the desktop tarball and MSI. None of the removed assets had been downloaded. This change stops it happening again.

### Workflow

Both build jobs still compile the CLI and still run the bundled `--version` smoke test, so the regression coverage from #131 is untouched. They just no longer stage CLI output for upload, so releases carry the desktop app only. The `Generate package-manager manifests` step is dropped along with it, since there are no CLI assets to describe.

`packaging/generate-cli-package-metadata.sh` is deliberately kept. It is unused by CI now, but it is what will produce the AUR and winget manifests when the CLI does ship.

### Docs

- README's CLI section no longer points at release assets. It explains the CLI is unreleased and gives the Gradle commands to build each package from a checkout.
- The feature list marks the CLI as unreleased rather than advertising it as shipped.
- Removed the winget, AUR and APT-repository instructions; those are deferred until there is something to submit.
- The desktop tarball is now referred to as `latch-<version>-linux-x64.tar.gz` instead of a pinned `1.3.8` filename that goes stale every release.

### Changelog

The 1.3.9 entry no longer announces the CLI as a new feature, and closes by saying the command line app is unreleased and not part of the downloads. `What's new` is now just the credentials screen change.

Verified `packaging/extract-release-notes.sh` still produces the intended body for 1.3.9 and that 1.3.8, 1.3.7 and 1.3.6 still extract. `actionlint` with shellcheck is clean.