### PR TITLE
[Release]: Ship the CLI through package managers and release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,12 +100,16 @@ jobs:
       # release-assets/latch-cli-*.tar.gz. Staging into one directory first
       # makes the uploaded layout flat and independent of where Gradle wrote
       # each file.
-      # The CLI is built and smoke-tested above but deliberately not staged:
-      # it is unreleased, so releases carry the desktop app only.
+      # upload-artifact roots an artifact at the least common ancestor of its
+      # path patterns, so staging everything in one flat directory keeps the
+      # release assets flat regardless of where Gradle wrote each file.
       - name: Stage Linux artifacts
         run: |
           mkdir -p staging
           cp desktop/build/distributions/*.tar.gz staging/
+          cp cli/build/distributions/*.tar.gz staging/
+          cp cli/build/distributions/*.deb staging/
+          cp cli/build/distributions/*.rpm staging/
           ls -l staging
 
       - name: Upload Linux artifacts
@@ -142,13 +146,13 @@ jobs:
             throw "Unexpected CLI version output: $actual"
           }
 
-      # Flattened for the same reason as the Linux job above, and likewise
-      # desktop-only while the CLI is unreleased.
+      # Flattened for the same reason as the Linux job above.
       - name: Stage Windows artifacts
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force -Path staging | Out-Null
           Copy-Item desktop\build\compose\binaries\main-release\msi\*.msi staging\
+          Copy-Item cli\build\distributions\*.zip staging\
           Get-ChildItem staging
 
       - name: Upload Windows artifacts
@@ -177,6 +181,20 @@ jobs:
       # layout ever drifts again.
       - name: List downloaded artifacts
         run: ls -lR release-assets
+
+      # AUR, winget and chocolatey all fetch the CLI from these release assets,
+      # so their manifests are generated here against the exact files and
+      # checksums that ship.
+      - name: Generate package-manager manifests
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          packaging/generate-cli-package-metadata.sh \
+            "$VERSION" \
+            "release-assets/latch-cli-$VERSION-linux-x64.tar.gz" \
+            "release-assets/latch-cli-$VERSION-windows-x64.zip" \
+            package-metadata
+          (cd package-metadata && zip -qr "../release-assets/latch-cli-$VERSION-package-metadata.zip" .)
 
       - name: Generate checksums
         working-directory: release-assets

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-2026 VinnovateIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Latch is a Kotlin application developed by VinnovateIT that automates the login 
 - Automatic detection of VIT hostel WiFi networks
 - Auto-login with securely stored credentials
 - Logging and display of network usage statistics
-- Standalone CLI for Linux terminals and Windows PowerShell (unreleased, build from source)
+- Standalone CLI for Linux terminals and Windows PowerShell
 
 ## Prerequisites
 
@@ -58,35 +58,66 @@ Before you start, make sure you have:
 
 ### Command-line app
 
-**`latch-cli` is not released yet.** Releases carry the desktop app only, so
-there is nothing to install with `apt`, `dnf`, winget, or the AUR at this point.
-Build it from a checkout instead:
+`latch-cli` bundles its own trimmed Java runtime, so Java does not need to be
+installed separately.
+
+Package-manager installs become available as each channel is published; until
+then, download the package for your system from the
+[latest release](https://github.com/vinnovateit/latch/releases/latest).
+
+**Arch Linux**, from the AUR:
 
 ```sh
-./gradlew :cli:packageCliTarGz   # portable tarball
-./gradlew :cli:packageCliDeb     # .deb
-./gradlew :cli:packageCliRpm     # .rpm
+yay -S latch-cli-bin        # or: paru -S latch-cli-bin
 ```
 
-On Windows:
+`sudo pacman -S latch-cli` will not find it. The AUR is not a pacman repository,
+so it needs an AUR helper, or a manual build:
+
+```sh
+git clone https://aur.archlinux.org/latch-cli-bin.git
+cd latch-cli-bin && makepkg -si
+```
+
+**Windows**, with winget or Chocolatey:
 
 ```powershell
-.\gradlew.bat :cli:packageCliZip
+winget install VinnovateIT.LatchCLI
+choco install latch-cli
 ```
 
-Packages land in `cli/build/distributions/`, and the runnable image is at
-`cli/build/cli-package/image/latch-cli/`. Each bundle carries its own trimmed
-Java runtime, so Java does not need to be installed separately. On Windows the
-executable works directly from PowerShell:
+**Debian and Ubuntu.** Unlike the above, apt needs the repository added once
+before the install works, because Latch is not in the Debian or Ubuntu
+archives:
+
+```sh
+curl -fsSL https://vinnovateit.github.io/latch/latch.gpg \
+  | sudo tee /usr/share/keyrings/latch.gpg > /dev/null
+echo "deb [signed-by=/usr/share/keyrings/latch.gpg] \
+  https://vinnovateit.github.io/latch/apt stable main" \
+  | sudo tee /etc/apt/sources.list.d/latch.list
+sudo apt update
+sudo apt install latch-cli
+```
+
+**Fedora and RPM-based distributions**, likewise adding the repository first:
+
+```sh
+sudo dnf config-manager --add-repo https://vinnovateit.github.io/latch/latch.repo
+sudo dnf install latch-cli
+```
+
+**Direct download.** The [latest release](https://github.com/vinnovateit/latch/releases/latest)
+carries a `.deb`, an `.rpm`, a portable Linux tarball and a Windows ZIP, with
+`SHA256SUMS` alongside them. On Windows the executable runs straight from the
+extracted folder:
 
 ```powershell
 .\latch-cli.exe --status
 ```
 
-Packaging targets, a hosted APT repository, and the winget and AUR submissions
-are all deferred until the CLI is actually published. Flatpak is intentionally
-out of scope because its sandbox and desktop-first distribution model do not fit
-a host-network command-line daemon.
+Flatpak is intentionally out of scope: its sandbox and desktop-first
+distribution model do not fit a host-network command-line daemon.
 
 Run `latch-cli` with no arguments the first time. It prompts for your VIT credentials, starts the auto-login daemon in the background, and enables per-user startup at login. On later runs, `latch-cli` prints its help menu.
 
@@ -114,7 +145,11 @@ Desktop and CLI installations can coexist. They coordinate through an authentica
 
 ### Android
 
-No pre-built APK is currently published for the Android app. To use it today, build it from source. See [Dev setup](#dev-setup) below.
+Latch is on Google Play:
+
+[**Get Latch on Google Play**](https://play.google.com/store/apps/details?id=com.vinnovateit.latch)
+
+To build it from source instead, see [Dev setup](#dev-setup) below.
 
 ## Dev setup
 
@@ -188,3 +223,7 @@ Optionally, it records network statistics for monitoring purposes.
 See the [open issues](https://github.com/vinnovateit/latch/issues) for a full list of proposed features and known issues.
 
 Made with love by [VinnovateIT](https://vinnovateit.com).
+
+## License
+
+Latch is released under the [MIT License](LICENSE).

--- a/packaging/generate-cli-package-metadata.sh
+++ b/packaging/generate-cli-package-metadata.sh
@@ -36,7 +36,8 @@ linux_sha=$(sha256sum "$linux_archive" | awk '{print $1}')
 windows_sha=$(sha256sum "$windows_archive" | awk '{print toupper($1)}')
 aur_dir="$output_dir/aur"
 winget_dir="$output_dir/winget/VinnovateIT.LatchCLI/$version"
-mkdir -p "$aur_dir" "$winget_dir"
+choco_dir="$output_dir/chocolatey"
+mkdir -p "$aur_dir" "$winget_dir" "$choco_dir/tools"
 
 cat > "$aur_dir/PKGBUILD" <<EOF
 # Maintainer: VinnovateIT
@@ -136,4 +137,76 @@ ManifestType: defaultLocale
 ManifestVersion: 1.10.0
 EOF
 
-echo "Generated AUR and winget metadata for v$version in $output_dir"
+# Chocolatey downloads the same Windows ZIP the winget manifest points at, and
+# verifies it against the same checksum. Nothing is embedded in the .nupkg, so
+# the package stays small and there is one artifact to trust.
+cat > "$choco_dir/latch-cli.nuspec" <<EOF
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>latch-cli</id>
+    <version>$version</version>
+    <packageSourceUrl>https://github.com/vinnovateit/latch/tree/main/packaging</packageSourceUrl>
+    <owners>VinnovateIT</owners>
+    <title>Latch CLI</title>
+    <authors>VinnovateIT</authors>
+    <projectUrl>https://github.com/vinnovateit/latch</projectUrl>
+    <projectSourceUrl>https://github.com/vinnovateit/latch</projectSourceUrl>
+    <bugTrackerUrl>https://github.com/vinnovateit/latch/issues</bugTrackerUrl>
+    <licenseUrl>https://github.com/vinnovateit/latch/blob/main/LICENSE</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <tags>latch cli wifi vit network captive-portal</tags>
+    <summary>Automatic VIT hostel Wi-Fi login from the terminal</summary>
+    <description>Latch CLI detects VIT hostel Wi-Fi networks, stores credentials securely, logs in automatically, and can share one active engine with the Latch Desktop app. The package bundles its own trimmed Java runtime, so Java does not need to be installed separately.</description>
+    <releaseNotes>https://github.com/vinnovateit/latch/releases/tag/v$version</releaseNotes>
+  </metadata>
+  <files>
+    <file src="tools\\**" target="tools" />
+  </files>
+</package>
+EOF
+
+cat > "$choco_dir/tools/chocolateyInstall.ps1" <<EOF
+\$ErrorActionPreference = 'Stop'
+
+\$toolsDir = Split-Path -Parent \$MyInvocation.MyCommand.Definition
+
+# Unzipping into the tools directory is what gets latch-cli.exe shimmed onto
+# PATH; Chocolatey shims every executable it finds there.
+Install-ChocolateyZipPackage \`
+  -PackageName 'latch-cli' \`
+  -Url 'https://github.com/vinnovateit/latch/releases/download/v$version/latch-cli-$version-windows-x64.zip' \`
+  -UnzipLocation \$toolsDir \`
+  -Checksum '$windows_sha' \`
+  -ChecksumType 'sha256'
+EOF
+
+cat > "$choco_dir/tools/chocolateyUninstall.ps1" <<'EOF'
+$ErrorActionPreference = 'Stop'
+
+# Install-ChocolateyZipPackage records what it extracted, so removing the
+# package directory is enough; the shim goes with it.
+Uninstall-ChocolateyZipPackage -PackageName 'latch-cli' -ZipFileName 'latch-cli-windows-x64.zip'
+EOF
+
+# Chocolatey moderation requires this for any package that fetches a binary.
+cat > "$choco_dir/tools/VERIFICATION.txt" <<EOF
+VERIFICATION
+
+This package downloads the official Latch CLI archive published by VinnovateIT:
+
+  https://github.com/vinnovateit/latch/releases/download/v$version/latch-cli-$version-windows-x64.zip
+
+Its SHA256 checksum is pinned in tools/chocolateyInstall.ps1 as:
+
+  $windows_sha
+
+To verify, download the archive from the URL above and compare:
+
+  Get-FileHash latch-cli-$version-windows-x64.zip -Algorithm SHA256
+
+The archive is built from tag v$version by the release workflow in
+https://github.com/vinnovateit/latch/blob/main/.github/workflows/release.yml
+EOF
+
+echo "Generated AUR, winget and chocolatey metadata for v$version in $output_dir"


### PR DESCRIPTION
Four commits preparing CLI distribution. `main` is protected, so this goes through a PR despite being a direct-to-main request.

### Release assets carry the CLI again

PR #134 removed the CLI packages from releases while the CLI was unreleased, and dropped the package-manager manifest step with them. Both come back: the Linux job stages the tarball, `.deb` and `.rpm`, the Windows job stages the ZIP, and the release job regenerates the AUR, winget and Chocolatey manifests against the exact files and checksums that ship.

This is what unblocks three of the five channels. AUR, winget and Chocolatey all need a hosted URL with a checksum, and release assets are exactly that, so none of them need separate hosting.

### Chocolatey packaging

New, and the only one of the five with nothing written before. `packaging/generate-cli-package-metadata.sh` now emits a `chocolatey/` package next to the AUR and winget output:

- `latch-cli.nuspec`
- `tools/chocolateyInstall.ps1`, downloading the same Windows ZIP the winget manifest points at, pinned to the same SHA256
- `tools/chocolateyUninstall.ps1`
- `tools/VERIFICATION.txt`, which Chocolatey moderation requires for any package that fetches a binary

Nothing is embedded in the `.nupkg`, so the package stays small and there is one artifact to trust. Verified by generating against real 1.4.0-named artifacts: all nine files emit, and the checksum matches the archive.

### LICENSE

The repository had no licence file at all, while `cli/build.gradle.kts` passes `--linux-rpm-license-type MIT` and the AUR and winget manifests both declare MIT. Chocolatey moderation asks for one too, and the nuspec's `licenseUrl` pointed at a file that did not exist. Added as MIT, 2025-2026 VinnovateIT, matching what was already being claimed.

### README

- The CLI section no longer says it is unreleased and no longer tells people to build from source. It documents each channel, and is explicit that apt and dnf need the repository added first because Latch is not in the Debian or Fedora archives, and that `pacman -S` will not find an AUR package.
- Notes that package-manager installs become available as each channel is published, since none are live yet.
- The Android section links the Play Store listing instead of stating no APK is published.
- Added a License section, which the repository standard requires and which was missing.

### Not in this change

apt and dnf repositories. Both need a GPG signing key and somewhere to host the metadata; the README documents the eventual `vinnovateit.github.io/latch` URLs so the shape is settled, but nothing serves them yet.