### PR TITLE
[Packaging]: Publish signed APT and DNF repositories on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,3 +224,68 @@ jobs:
           name: |
             linux-artifacts
             windows-artifacts
+
+  publish-repos:
+    name: Publish Linux repositories
+    needs: [prepare, release]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      # The published site is a branch, not a directory in main. Cloning it
+      # rather than rebuilding from scratch is what keeps older releases
+      # installable: the indexes are regenerated over everything present.
+      - name: Fetch the published site
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if ! git clone --branch gh-pages --depth 1 \
+              "https://x-access-token:$GH_TOKEN@github.com/$GITHUB_REPOSITORY.git" site; then
+            echo "gh-pages does not exist yet; starting it"
+            git clone --depth 1 \
+              "https://x-access-token:$GH_TOKEN@github.com/$GITHUB_REPOSITORY.git" site
+            git -C site checkout --orphan gh-pages
+            git -C site rm -rq --cached .
+            find site -mindepth 1 -maxdepth 1 -not -name .git -exec rm -rf {} +
+          fi
+
+      - name: Install packaging tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes apt-utils createrepo-c rpm
+
+      - name: Import the signing key
+        env:
+          SIGNING_KEY: ${{ secrets.PACKAGE_SIGNING_KEY }}
+        run: printf '%s' "$SIGNING_KEY" | gpg --batch --import
+
+      - name: Download the CLI packages from the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+        run: |
+          mkdir -p artifacts
+          gh release download "$TAG" --dir artifacts --pattern '*.deb' --pattern '*.rpm'
+
+      - name: Build the APT and DNF repositories
+        env:
+          KEY_ID: ${{ secrets.PACKAGE_SIGNING_KEY_ID }}
+        run: packaging/build-linux-repos.sh site "$KEY_ID" artifacts
+
+      - name: Publish
+        env:
+          TAG: ${{ needs.prepare.outputs.tag }}
+        run: |
+          cd site
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "nothing changed"
+            exit 0
+          fi
+          git commit -m "Publish Latch $TAG to the APT and DNF repositories"
+          git push origin gh-pages

--- a/packaging/build-linux-repos.sh
+++ b/packaging/build-linux-repos.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Builds signed APT and DNF repositories from the CLI's .deb and .rpm packages.
+#
+# Both are static file trees, so the output is published as-is to GitHub Pages.
+# Existing packages in <site> are kept and reindexed, so older versions stay
+# installable after a new release.
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+    echo "Usage: $0 <site-dir> <gpg-key-id> <artifacts-dir>" >&2
+    exit 2
+fi
+
+site=$1
+key_id=$2
+artifacts=$3
+
+base_url="https://vinnovateit.github.io/latch"
+origin="Latch"
+suite="stable"
+component="main"
+architecture="amd64"
+
+shopt -s nullglob
+debs=("$artifacts"/*.deb)
+rpms=("$artifacts"/*.rpm)
+shopt -u nullglob
+
+if [[ ${#debs[@]} -eq 0 && ${#rpms[@]} -eq 0 ]]; then
+    echo "No .deb or .rpm found in $artifacts" >&2
+    exit 2
+fi
+
+# ---------------------------------------------------------------- APT --------
+pool="$site/apt/pool/$component/l/latch-cli"
+index_dir="$site/apt/dists/$suite/$component/binary-$architecture"
+mkdir -p "$pool" "$index_dir"
+
+for deb in "${debs[@]}"; do
+    cp -f "$deb" "$pool/"
+done
+
+# Paths inside Packages must be relative to the apt root, so scan from there.
+(
+    cd "$site/apt"
+    # --multiversion indexes every version in the pool, not just the newest, so
+    # a user can pin or downgrade if a release turns out to be broken.
+    dpkg-scanpackages --multiversion --arch "$architecture" pool \
+        > "dists/$suite/$component/binary-$architecture/Packages"
+    gzip -9cn "dists/$suite/$component/binary-$architecture/Packages" \
+        > "dists/$suite/$component/binary-$architecture/Packages.gz"
+
+    apt-ftparchive \
+        -o "APT::FTPArchive::Release::Origin=$origin" \
+        -o "APT::FTPArchive::Release::Label=$origin" \
+        -o "APT::FTPArchive::Release::Suite=$suite" \
+        -o "APT::FTPArchive::Release::Codename=$suite" \
+        -o "APT::FTPArchive::Release::Architectures=$architecture" \
+        -o "APT::FTPArchive::Release::Components=$component" \
+        -o "APT::FTPArchive::Release::Description=Latch CLI packages" \
+        release "dists/$suite" > "dists/$suite/Release"
+
+    # InRelease is the inline-signed form apt prefers; Release.gpg is the
+    # detached signature older clients look for. Publish both.
+    rm -f "dists/$suite/InRelease" "dists/$suite/Release.gpg"
+    gpg --batch --yes --local-user "$key_id" \
+        --clearsign -o "dists/$suite/InRelease" "dists/$suite/Release"
+    gpg --batch --yes --local-user "$key_id" \
+        --armor --detach-sign -o "dists/$suite/Release.gpg" "dists/$suite/Release"
+)
+
+# ---------------------------------------------------------------- DNF --------
+if [[ ${#rpms[@]} -gt 0 ]]; then
+    mkdir -p "$site/rpm"
+    for rpm_file in "${rpms[@]}"; do
+        cp -f "$rpm_file" "$site/rpm/"
+    done
+
+    # Sign the packages themselves, not just the metadata, so dnf verifies at
+    # both levels with gpgcheck and repo_gpgcheck on.
+    #
+    # __gpg has to be set explicitly: rpm defaults it to a gpg2 binary that does
+    # not exist on Debian-family systems, and the failure is a bare "Could not
+    # exec gpg". The loopback pinentry keeps it from reaching for a tty.
+    rpm --define "_gpg_name $key_id" \
+        --define "__gpg $(command -v gpg)" \
+        --define "_gpg_sign_cmd_extra_args --batch --pinentry-mode loopback --yes" \
+        --addsign "$site"/rpm/*.rpm
+
+    createrepo_c --update "$site/rpm"
+    rm -f "$site/rpm/repodata/repomd.xml.asc"
+    gpg --batch --yes --local-user "$key_id" \
+        --armor --detach-sign "$site/rpm/repodata/repomd.xml"
+fi
+
+# ------------------------------------------------------------- key + docs ----
+gpg --export "$key_id" > "$site/latch.gpg"
+gpg --armor --export "$key_id" > "$site/latch.gpg.asc"
+
+cat > "$site/latch.repo" <<EOF
+[latch]
+name=Latch
+baseurl=$base_url/rpm
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=$base_url/latch.gpg.asc
+EOF
+
+cat > "$site/index.html" <<EOF
+<!doctype html>
+<meta charset="utf-8">
+<title>Latch package repositories</title>
+<style>
+body{font:16px/1.6 system-ui,sans-serif;max-width:46rem;margin:3rem auto;padding:0 1rem}
+pre{background:#f4f4f5;padding:1rem;overflow-x:auto;border-radius:6px}
+code{font:14px/1.5 ui-monospace,monospace}
+</style>
+<h1>Latch package repositories</h1>
+<p>APT and DNF repositories for <a href="https://github.com/vinnovateit/latch">Latch CLI</a>.</p>
+
+<h2>Debian and Ubuntu</h2>
+<pre><code>curl -fsSL $base_url/latch.gpg | sudo tee /usr/share/keyrings/latch.gpg > /dev/null
+echo "deb [signed-by=/usr/share/keyrings/latch.gpg] $base_url/apt $suite $component" | sudo tee /etc/apt/sources.list.d/latch.list
+sudo apt update
+sudo apt install latch-cli</code></pre>
+
+<h2>Fedora and RPM-based</h2>
+<pre><code>sudo dnf config-manager --add-repo $base_url/latch.repo
+sudo dnf install latch-cli</code></pre>
+
+<p>Signing key fingerprint: <code>$key_id</code></p>
+EOF
+
+# GitHub Pages runs Jekyll by default, which would skip the repodata directory
+# and anything else it considers special.
+touch "$site/.nojekyll"
+
+echo "Built repositories in $site"


### PR DESCRIPTION
Adds the two channels that need self-hosting. AUR, winget and Chocolatey fetch from release assets and need nothing new; apt and dnf have no index to submit to, so we publish the repositories ourselves to GitHub Pages.

### What it does

`packaging/build-linux-repos.sh` builds both repositories from the `.deb` and `.rpm` in a directory:

- **APT**: `pool/` plus `dists/stable/main/binary-amd64/Packages(.gz)`, a `Release` generated by `apt-ftparchive`, and both `InRelease` (inline signed) and `Release.gpg` (detached) so old and new clients are covered.
- **DNF**: the RPMs signed with `rpm --addsign`, `repodata/` from `createrepo_c`, and a detached signature over `repomd.xml`. Signing at both levels means `gpgcheck` and `repo_gpgcheck` can both be on.
- The public key in both binary and armored form, a `latch.repo`, an index page with copy-paste instructions, and `.nojekyll` so Pages does not skip `repodata/`.

A `publish-repos` job in the release workflow clones the existing `gh-pages`, adds the new packages, reindexes over everything and pushes. Existing packages are kept, so older releases stay installable.

### Verified end to end in a container

Not just linted. Built both repositories with an Ed25519 key matching the one in use, then:

- All three signatures verify: `InRelease`, `Release.gpg`, `repomd.xml.asc`
- The RPM is signed `EdDSA/SHA512`, confirming Ed25519 works for RPM signing on rpm 4.18
- `apt update` accepted the repository through `signed-by`, and `apt install latch-cli` **installed and ran the binary**
- A second release into the same site kept both versions in the pool and the repodata

### Two bugs the test caught

**`rpm --addsign` failed outright** with "Could not exec gpg: No such file or directory". RPM defaults `%__gpg` to a `gpg2` binary that does not exist on Debian-family systems, which is what the runner is. Fixed by setting `__gpg` explicitly and using loopback pinentry so it does not reach for a tty. This would have failed on the first real release.

**`dpkg-scanpackages` indexed only the newest version**, so older releases sat in the pool but were not installable. `--multiversion` fixes that, which matters for pinning or downgrading if a release turns out to be broken.

### Still needed before this works

- `PACKAGE_SIGNING_KEY` and `PACKAGE_SIGNING_KEY_ID` secrets: set.
- GitHub Pages: the API still reports no Pages site, which is expected while `gh-pages` does not exist. The first release run creates the branch; the Pages source may need re-confirming afterwards.
- Ed25519 is verified working on rpm 4.18. It will not verify on rpm 4.14 (RHEL/Rocky/Alma 8, openSUSE Leap 15), which would need a separate RSA key if those matter.