### PR TITLE
[Packaging]: Automate winget submissions on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -289,3 +289,30 @@ jobs:
           fi
           git commit -m "Publish Latch $TAG to the APT and DNF repositories"
           git push origin gh-pages
+
+  submit-winget:
+    name: Submit to winget
+    needs: [prepare, release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Fetch the generated manifests
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          gh release download "$TAG" --pattern '*-package-metadata.zip' --dir .
+          unzip -q "latch-cli-$VERSION-package-metadata.zip" -d package-metadata
+
+      # A repository-scoped token cannot push to a fork in another org, so this
+      # needs a PAT with public_repo rather than GITHUB_TOKEN.
+      - name: Open the winget pull request
+        env:
+          GH_TOKEN: ${{ secrets.WINGET_TOKEN }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          packaging/submit-winget.sh "$VERSION" \
+            "package-metadata/winget/VinnovateIT.LatchCLI/$VERSION"

--- a/README.md
+++ b/README.md
@@ -65,30 +65,14 @@ Package-manager installs become available as each channel is published; until
 then, download the package for your system from the
 [latest release](https://github.com/vinnovateit/latch/releases/latest).
 
-**Arch Linux**, from the AUR:
-
-```sh
-yay -S latch-cli-bin        # or: paru -S latch-cli-bin
-```
-
-`sudo pacman -S latch-cli` will not find it. The AUR is not a pacman repository,
-so it needs an AUR helper, or a manual build:
-
-```sh
-git clone https://aur.archlinux.org/latch-cli-bin.git
-cd latch-cli-bin && makepkg -si
-```
-
-**Windows**, with winget or Chocolatey:
+**Windows**, with winget:
 
 ```powershell
 winget install VinnovateIT.LatchCLI
-choco install latch-cli
 ```
 
-**Debian and Ubuntu.** Unlike the above, apt needs the repository added once
-before the install works, because Latch is not in the Debian or Ubuntu
-archives:
+**Debian and Ubuntu.** Unlike winget, apt needs the repository added once before
+the install works, because Latch is not in the Debian or Ubuntu archives:
 
 ```sh
 curl -fsSL https://vinnovateit.github.io/latch/latch.gpg \

--- a/packaging/submit-winget.sh
+++ b/packaging/submit-winget.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Opens a winget-pkgs pull request for one released version.
+#
+# Works entirely through the GitHub API rather than cloning: winget-pkgs holds
+# roughly a million files and we are adding three.
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+    echo "Usage: $0 <version> <manifest-dir>" >&2
+    echo "  manifest-dir holds the three VinnovateIT.LatchCLI.*.yaml files" >&2
+    exit 2
+fi
+
+version=$1
+manifest_dir=$2
+
+: "${GH_TOKEN:?a token with public_repo scope is required}"
+
+upstream="microsoft/winget-pkgs"
+fork="vinnovateit/winget-pkgs"
+package_path="manifests/v/VinnovateIT/LatchCLI/$version"
+branch="latch-cli-$version"
+
+shopt -s nullglob
+manifests=("$manifest_dir"/*.yaml)
+shopt -u nullglob
+if [[ ${#manifests[@]} -eq 0 ]]; then
+    echo "No manifests found in $manifest_dir" >&2
+    exit 2
+fi
+
+default_branch=$(gh api "repos/$upstream" --jq .default_branch)
+echo "Upstream default branch: $default_branch"
+
+# A stale fork would branch from old history; the PR would still apply, but
+# syncing keeps the diff to just our three files.
+gh repo sync "$fork" --source "$upstream" --branch "$default_branch" --force
+
+base_sha=$(gh api "repos/$fork/git/ref/heads/$default_branch" --jq .object.sha)
+
+# Re-running a release should not fail on a leftover branch.
+if gh api "repos/$fork/git/ref/heads/$branch" >/dev/null 2>&1; then
+    echo "Branch $branch already exists on the fork; replacing it"
+    gh api -X DELETE "repos/$fork/git/refs/heads/$branch"
+fi
+
+gh api -X POST "repos/$fork/git/refs" \
+    -f "ref=refs/heads/$branch" \
+    -f "sha=$base_sha" > /dev/null
+echo "Created $fork:$branch from $base_sha"
+
+for manifest in "${manifests[@]}"; do
+    name=$(basename "$manifest")
+    gh api -X PUT "repos/$fork/contents/$package_path/$name" \
+        -f "message=Add VinnovateIT.LatchCLI $version ($name)" \
+        -f "content=$(base64 -w0 < "$manifest")" \
+        -f "branch=$branch" > /dev/null
+    echo "Added $package_path/$name"
+done
+
+pr_url=$(gh pr create \
+    --repo "$upstream" \
+    --base "$default_branch" \
+    --head "vinnovateit:$branch" \
+    --title "New version: VinnovateIT.LatchCLI version $version" \
+    --body "Automated submission from the [Latch release workflow](https://github.com/vinnovateit/latch/blob/main/.github/workflows/release.yml).
+
+- Installer: https://github.com/vinnovateit/latch/releases/download/v$version/latch-cli-$version-windows-x64.zip
+- Release: https://github.com/vinnovateit/latch/releases/tag/v$version
+
+Checksums in the manifest are generated from the published release assets.")
+
+echo "Opened $pr_url"


### PR DESCRIPTION
Adds automated winget submission to the release workflow:

- `submit-winget` job in `.github/workflows/release.yml` that downloads generated manifests and opens a PR against `microsoft/winget-pkgs`
- `packaging/submit-winget.sh` script that handles fork sync, branch creation, manifest upload, and PR creation via GitHub API
- README cleanup: removes AUR and Chocolatey from install instructions (not yet available), fixes dangling "Unlike the above" reference