### PR TITLE
[Release]: Bump version to 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ that release's body, so a release is only as good as its entry in this file. Add
 the section in the same commit that bumps the version; the release job fails
 before it builds anything if the section is missing.
 
+## 1.4.0
+
+The CLI's first public release. Install it from the package manager for your
+system, or download the binary from the assets below.
+
+### What's new
+
+- **CLI**: animated ASCII intro banner on launch
+- **CLI**: published to apt, dnf, and winget for the first time
+- **Linux**: signed apt and dnf repositories hosted on GitHub Pages
+- **Windows**: automated winget submissions on every release
+- **Packaging**: AUR, Chocolatey, and winget manifest generation on every release
+- Added MIT license file
+
+Download the compatible version for your machine from the assets below.
+
 ## 1.3.9
 
 ### What's new

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-latchVersion=1.3.9
+latchVersion=1.4.0
 # Enables namespacing of each library's R class so that its R class includes only the
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library


### PR DESCRIPTION
Bumps version to 1.4.0 and adds changelog entry for the CLI's first public release.

### What's new in 1.4.0

- **CLI**: animated ASCII intro banner on launch
- **CLI**: published to apt, dnf, and winget for the first time
- **Linux**: signed apt and dnf repositories hosted on GitHub Pages
- **Windows**: automated winget submissions on every release
- **Packaging**: AUR, Chocolatey, and winget manifest generation on every release
- Added MIT license file