### PR TITLE
[Fix]: Release workflow – GPG pinentry and winget sync

### DIFF
--- a/packaging/build-linux-repos.sh
+++ b/packaging/build-linux-repos.sh
@@ -63,9 +63,9 @@ done
     # InRelease is the inline-signed form apt prefers; Release.gpg is the
     # detached signature older clients look for. Publish both.
     rm -f "dists/$suite/InRelease" "dists/$suite/Release.gpg"
-    gpg --batch --yes --local-user "$key_id" \
+    gpg --batch --yes --pinentry-mode loopback --local-user "$key_id" \
         --clearsign -o "dists/$suite/InRelease" "dists/$suite/Release"
-    gpg --batch --yes --local-user "$key_id" \
+    gpg --batch --yes --pinentry-mode loopback --local-user "$key_id" \
         --armor --detach-sign -o "dists/$suite/Release.gpg" "dists/$suite/Release"
 )
 
@@ -89,7 +89,7 @@ if [[ ${#rpms[@]} -gt 0 ]]; then
 
     createrepo_c --update "$site/rpm"
     rm -f "$site/rpm/repodata/repomd.xml.asc"
-    gpg --batch --yes --local-user "$key_id" \
+    gpg --batch --yes --pinentry-mode loopback --local-user "$key_id" \
         --armor --detach-sign "$site/rpm/repodata/repomd.xml"
 fi
 

--- a/packaging/submit-winget.sh
+++ b/packaging/submit-winget.sh
@@ -33,8 +33,11 @@ default_branch=$(gh api "repos/$upstream" --jq .default_branch)
 echo "Upstream default branch: $default_branch"
 
 # A stale fork would branch from old history; the PR would still apply, but
-# syncing keeps the diff to just our three files.
-gh repo sync "$fork" --source "$upstream" --branch "$default_branch" --force
+# syncing keeps the diff to just our three files. If the PAT lacks permission
+# to sync (403), continue anyway — the PR will still be created.
+if ! gh repo sync "$fork" --source "$upstream" --branch "$default_branch" --force; then
+    echo "Warning: fork sync failed (token may lack repo scope); continuing anyway" >&2
+fi
 
 base_sha=$(gh api "repos/$fork/git/ref/heads/$default_branch" --jq .object.sha)
 


### PR DESCRIPTION
Two fixes for the v1.4.0 release workflow:

1. **APT/RPM GPG signing**: add `--pinentry-mode loopback` so gpg doesn't try to read from a tty in CI
2. **winget submission**: make `gh repo sync` non-fatal — if the PAT lacks repo scope (403), the PR is still created successfully