### PR TITLE
docs(stats): correct the portal sync comment to match the Wi-Fi guard

### DIFF
--- a/core/src/commonMain/kotlin/com/vinnovateit/latch/core/domain/SessionRepository.kt
+++ b/core/src/commonMain/kotlin/com/vinnovateit/latch/core/domain/SessionRepository.kt
@@ -224,10 +224,11 @@ class SessionRepository(
         }
 
         return try {
-            // The portal endpoint is a static public IP reachable over any internet
-            // connection. Resolve the active Wi-Fi handle: if present it binds the
-            // request to the Wi-Fi NIC; if null the transport uses the system default
-            // network, allowing resync over cellular or regular Wi-Fi as well.
+            // Bind the request to the Wi-Fi network, and refuse to sync without
+            // one. Falling back to the process default network would ship these
+            // credentials in cleartext over whatever that happens to be, which on
+            // Android stays cellular while a captive portal is unvalidated. See the
+            // "No Cellular Leaks" invariant in AGENTS.md.
             val handle = activeHandle()
             if (handle == null) {
                 logger.w(TAG, "No active Wi-Fi network; skipping portal sync rather than leaving the network.")


### PR DESCRIPTION
`#146` rewrote the comment above the portal sync guard to describe a cellular fallback, but left the guard itself in place. The comment and the four lines beneath it now say opposite things.

On `main` today:

```kotlin
// The portal endpoint is a static public IP reachable over any internet
// connection. ... if null the transport uses the system default
// network, allowing resync over cellular or regular Wi-Fi as well.
val handle = activeHandle()
if (handle == null) {
    logger.w(TAG, "No active Wi-Fi network; skipping portal sync rather than leaving the network.")
    return Result.failure(IllegalStateException("Not connected to Wi-Fi"))
}
```

The comment promises a fallback the code refuses to perform. This PR makes the comment describe the actual behaviour and points at the invariant it enforces. **No behaviour change**, comment only.

`#146`'s commit message says it removed the Wi-Fi-only guard "from `refreshHistory()` in StatsViewModel and from `syncPortalHistory()` in SessionRepository". The `StatsViewModel` half landed; the `SessionRepository` half did not. So one of two things is true:

- **The feature is half-landed.** Cellular resync does not actually work, and finishing it means deleting the `if (handle == null)` block. That would reopen the credentials-over-cellular path, which conflicts with the "No Cellular Leaks (STRICT)" invariant added in `AGENTS.md`.
- **You changed your mind mid-PR.** The code is right and only the comment was left behind, which is what this PR assumes.

If it is the first, close this and I will raise the guard removal separately so the security tradeoff gets its own discussion.
