### PR TITLE
feat: sync portal history on any internet connection, trigger on login

### DIFF
--- a/app/src/main/java/com/vinnovateit/latch/features/stats/StatsViewModel.kt
+++ b/app/src/main/java/com/vinnovateit/latch/features/stats/StatsViewModel.kt
@@ -3,33 +3,28 @@ package com.vinnovateit.latch.features.stats
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
-import com.vinnovateit.latch.core.stats.formatDate
 import com.vinnovateit.latch.core.model.AggregatedDayRecord
 import com.vinnovateit.latch.core.model.DataUsage
-import com.vinnovateit.latch.core.model.DateRangeFilter
 import com.vinnovateit.latch.core.model.HistoryChartItem
 import com.vinnovateit.latch.core.model.PortalSessionRecord
 import com.vinnovateit.latch.core.model.SessionSummary
 import com.vinnovateit.latch.core.model.StatsOverviewMetrics
 import com.vinnovateit.latch.core.stats.StatsInsights
 import com.vinnovateit.latch.core.stats.computeChartItems
+import com.vinnovateit.latch.core.stats.formatDate
 import com.vinnovateit.latch.platform.LatchAppGraph
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
-import java.util.Calendar
 
 class StatsViewModel(application: Application) : AndroidViewModel(application) {
 
-  // Data now comes from the single source of truth: SessionRepository
   val liveStatus = LatchAppGraph.sessions.liveStatus
   val lastSession = LatchAppGraph.sessions.lastSession
-  private val sessionHistory = LatchAppGraph.sessions.sessionSummaries
 
   val portalHistory: StateFlow<List<PortalSessionRecord>> = LatchAppGraph.sessions.portalHistory
   val isHistoryLoaded: StateFlow<Boolean> = LatchAppGraph.sessions.isHistoryLoaded
@@ -56,40 +51,32 @@ class StatsViewModel(application: Application) : AndroidViewModel(application) {
     LatchAppGraph.triggerHistorySync(force = force)
   }
 
-  // This flow combines live and last sessions to decide what to show in the UI.
+  // Combines live and last sessions to determine what to show in the UI.
   val sessionToShow: StateFlow<SessionSummary?> =
-    combine(
-      liveStatus,
-      lastSession,
-    ) { live, last ->
+    combine(liveStatus, lastSession) { live, last ->
       live?.let {
-        // Create a temporary summary for the UI from the live data
         SessionSummary(
           startTimestamp = it.startTimeMillis,
-          endTimestamp = System.currentTimeMillis(), // It's ongoing
+          endTimestamp = System.currentTimeMillis(),
           totalData = DataUsage(it.totalRxBytes, it.totalTxBytes),
           history = it.liveData,
           maxRxBps = it.maxRxBps,
           maxTxBps = it.maxTxBps
         )
-      } ?: last // If not live, show the last completed session
+      } ?: last
     }.stateIn(viewModelScope, SharingStarted.Lazily, null)
-
-
 
   val chartItems: StateFlow<List<HistoryChartItem>> =
     combine(nonZeroPortalHistory, liveStatus) { records, live ->
-      val liveRx = live?.totalRxBytes ?: 0L
-      val liveTx = live?.totalTxBytes ?: 0L
-      computeChartItems(records, liveRxBytes = liveRx, liveTxBytes = liveTx)
+      computeChartItems(
+        records,
+        liveRxBytes = live?.totalRxBytes ?: 0L,
+        liveTxBytes = live?.totalTxBytes ?: 0L
+      )
     }.flowOn(Dispatchers.Default)
       .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
 
   fun onClearHistory() {
     LatchAppGraph.sessions.clearHistory()
-  }
-
-  override fun onCleared() {
-    super.onCleared()
   }
 }

--- a/app/src/main/java/com/vinnovateit/latch/features/stats/StatsViewModel.kt
+++ b/app/src/main/java/com/vinnovateit/latch/features/stats/StatsViewModel.kt
@@ -22,7 +22,6 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.launch
 import java.util.Calendar
 
 class StatsViewModel(application: Application) : AndroidViewModel(application) {
@@ -54,16 +53,7 @@ class StatsViewModel(application: Application) : AndroidViewModel(application) {
   val statsInsights: StateFlow<StatsInsights> = LatchAppGraph.sessions.statsInsights
 
   fun refreshHistory(force: Boolean = false) {
-    val platform = LatchAppGraph.platform
-    if (platform.credentials.exists()) {
-      val userId = platform.credentials.userId()
-      val password = platform.credentials.password()
-      if (!userId.isNullOrBlank() && !password.isNullOrBlank()) {
-        viewModelScope.launch(Dispatchers.IO) {
-          LatchAppGraph.sessions.syncPortalHistory(userId, password, force = force)
-        }
-      }
-    }
+    LatchAppGraph.triggerHistorySync(force = force)
   }
 
   // This flow combines live and last sessions to decide what to show in the UI.

--- a/app/src/main/java/com/vinnovateit/latch/navigation/LatchNavGraph.kt
+++ b/app/src/main/java/com/vinnovateit/latch/navigation/LatchNavGraph.kt
@@ -179,6 +179,7 @@ fun LatchNavGraph(
                 CredentialsScreen(
                     editMode = editMode,
                     onCredentialsSaved = {
+                        LatchAppGraph.triggerHistorySync(force = true)
                         triggerBack()
                     }
                 )

--- a/app/src/main/java/com/vinnovateit/latch/platform/LatchAppGraph.kt
+++ b/app/src/main/java/com/vinnovateit/latch/platform/LatchAppGraph.kt
@@ -73,17 +73,7 @@ object LatchAppGraph {
 
         _engine = LatchEngine(platform, sessions)
 
-        if (platform.credentials.exists()) {
-            val userId = platform.credentials.userId()
-            val password = platform.credentials.password()
-            if (!userId.isNullOrBlank() && !password.isNullOrBlank()) {
-                CoroutineScope(Dispatchers.IO).launch {
-                    try {
-                        sessions.syncPortalHistory(userId, password)
-                    } catch (_: Exception) { }
-                }
-            }
-        }
+        triggerHistorySync()
 
         val appScope = CoroutineScope(Dispatchers.Main.immediate)
         appScope.launch {
@@ -108,6 +98,21 @@ object LatchAppGraph {
                     )
                 }
             }
+        }
+    }
+
+    /**
+     * Fire-and-forget history sync. Reads credentials from the platform store,
+     * so callers do not duplicate that logic. Safe to call any time -- the
+     * repository's atomic slot prevents overlapping syncs.
+     */
+    fun triggerHistorySync(force: Boolean = false) {
+        val creds = _platform?.credentials ?: return
+        if (!creds.exists()) return
+        val userId = creds.userId()?.takeIf { it.isNotBlank() } ?: return
+        val password = creds.password()?.takeIf { it.isNotBlank() } ?: return
+        CoroutineScope(Dispatchers.IO).launch {
+            try { _sessions?.syncPortalHistory(userId, password, force = force) } catch (_: Exception) { }
         }
     }
 }

--- a/app/src/main/java/com/vinnovateit/latch/platform/LatchAppGraph.kt
+++ b/app/src/main/java/com/vinnovateit/latch/platform/LatchAppGraph.kt
@@ -13,6 +13,7 @@ import com.vinnovateit.latch.core.settings.SettingsManager
 import com.vinnovateit.latch.core.stats.ThroughputMonitor
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 
 /**
@@ -43,6 +44,10 @@ object LatchAppGraph {
 
     lateinit var foregroundController: ForegroundControllerHolder
         private set
+
+    // Single application-lifetime scope shared by initialize() launchers and triggerHistorySync().
+    // Avoids spawning an orphan CoroutineScope on every sync call.
+    private val appScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
     fun initialize(context: Context) {
         if (_engine != null) return
@@ -75,7 +80,6 @@ object LatchAppGraph {
 
         triggerHistorySync()
 
-        val appScope = CoroutineScope(Dispatchers.Main.immediate)
         appScope.launch {
             SettingsManager.settingsChanged.collect {
                 appContext.sendBroadcast(android.content.Intent("com.vinnovateit.latch.ACTION_SETTINGS_CHANGED"))
@@ -90,7 +94,7 @@ object LatchAppGraph {
                 }
                 if (enabled) {
                     appContext.startService(android.content.Intent(appContext, com.vinnovateit.latch.features.wifi.background.ForegroundService::class.java))
-                } else if (_sessions?.liveStatus?.value != null) {
+                } else if (sessions.liveStatus.value != null) {
                     appContext.startService(
                         android.content.Intent(appContext, com.vinnovateit.latch.features.wifi.background.ForegroundService::class.java).apply {
                             action = com.vinnovateit.latch.features.wifi.background.ForegroundService.ACTION_TRIGGER_LOGOUT
@@ -107,12 +111,12 @@ object LatchAppGraph {
      * repository's atomic slot prevents overlapping syncs.
      */
     fun triggerHistorySync(force: Boolean = false) {
-        val creds = _platform?.credentials ?: return
+        val creds = platform.credentials
         if (!creds.exists()) return
         val userId = creds.userId()?.takeIf { it.isNotBlank() } ?: return
         val password = creds.password()?.takeIf { it.isNotBlank() } ?: return
-        CoroutineScope(Dispatchers.IO).launch {
-            try { _sessions?.syncPortalHistory(userId, password, force = force) } catch (_: Exception) { }
+        appScope.launch(Dispatchers.IO) {
+            try { sessions.syncPortalHistory(userId, password, force = force) } catch (_: Exception) { }
         }
     }
 }


### PR DESCRIPTION
## What

Portal endpoint `136.233.9.110` is a static public IP reachable over any internet connection — no WiFi, no active latch session needed.

## Changes

### `LatchAppGraph.kt`
- Add `triggerHistorySync(force)` — single entry point for all sync calls. Reads credentials internally; repository's atomic `isSyncing` slot prevents overlapping syncs.
- Startup auto-sync now calls `triggerHistorySync()` (replaces the 11-line inline block).

### `LatchNavGraph.kt`
- Call `triggerHistorySync(force = true)` in `onCredentialsSaved` — so history populates immediately after first login and after credential edits, without waiting for next startup.

### `StatsViewModel.kt`
- `refreshHistory()` now delegates to `triggerHistorySync()` — removes duplicated credential-reading logic.

## Loading indicator
`isSyncing` StateFlow is set to `true` for every sync path (startup, post-login, manual resync). `StatsScreen` already collects it and shows the spinner in the menu — so the indicator works for all triggers, not just manual taps.

## Files changed
- `app/.../LatchAppGraph.kt`
- `app/.../StatsViewModel.kt`
- `app/.../LatchNavGraph.kt`