### PR TITLE
feat(android): show live session data and Wi-Fi state in Quick Settings tile subtitle

### DIFF
--- a/app/src/main/java/com/vinnovateit/latch/features/wifi/quicksettings/LatchTileService.kt
+++ b/app/src/main/java/com/vinnovateit/latch/features/wifi/quicksettings/LatchTileService.kt
@@ -8,6 +8,7 @@ import android.service.quicksettings.TileService
 import android.util.Log
 import com.vinnovateit.latch.features.wifi.background.ForegroundService
 import com.vinnovateit.latch.core.settings.SettingsManager
+import com.vinnovateit.latch.core.stats.formatBytes
 import com.vinnovateit.latch.platform.LatchAppGraph
 import kotlinx.coroutines.*
 
@@ -24,6 +25,7 @@ class LatchTileService : TileService() {
     override fun onStartListening() {
         super.onStartListening()
         Log.d(TAG, "=== onStartListening called ===")
+        LatchAppGraph.initialize(applicationContext)
         updateTileState()
 
         serviceScope.launch {
@@ -124,7 +126,8 @@ class LatchTileService : TileService() {
         serviceScope.launch {
             try {
                 val qsTile = qsTile ?: return@launch
-                val isConnected = LatchAppGraph.sessions.liveStatus.value != null
+                val liveStatus = LatchAppGraph.sessions.liveStatus.value
+                val isConnected = liveStatus != null
 
                 val wifi = LatchAppGraph.platform.wifi
                 val isWifiReady = wifi.isWifiEnabled() && wifi.isConnectedToWifi()
@@ -132,23 +135,41 @@ class LatchTileService : TileService() {
                 if (!isWifiReady) {
                     qsTile.state = Tile.STATE_UNAVAILABLE
                     qsTile.label = "Latch"
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                        qsTile.subtitle = if (!wifi.isWifiEnabled()) "Wi-Fi off" else "Wi-Fi disconnected"
+                    }
                 } else {
+                    val ssid = wifi.currentSsid()
                     when {
                         isConnected && !isProcessing -> {
                             qsTile.state = Tile.STATE_ACTIVE
                             qsTile.label = "Latched"
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                                val totalBytes = liveStatus.totalRxBytes + liveStatus.totalTxBytes
+                                val (amount, unit) = formatBytes(totalBytes)
+                                qsTile.subtitle = "$amount $unit used"
+                            }
                         }
                         !isConnected && !isProcessing -> {
                             qsTile.state = Tile.STATE_INACTIVE
                             qsTile.label = "Latch"
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                                qsTile.subtitle = ssid ?: "Disconnected"
+                            }
                         }
                         isProcessing && isConnected -> {
                             qsTile.state = Tile.STATE_ACTIVE
                             qsTile.label = "Disconnecting..."
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                                qsTile.subtitle = null
+                            }
                         }
                         isProcessing && !isConnected -> {
                             qsTile.state = Tile.STATE_INACTIVE
                             qsTile.label = "Latching..."
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                                qsTile.subtitle = ssid
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
### Summary
On Android 10+ (API 29+), `Tile.subtitle` allows Quick Settings tiles to display context below the main title. This PR binds the existing `liveStatus` and Wi-Fi connection states to the Quick Settings tile subtitle:
- **Latched**: shows current session data usage formatted via `formatBytes` (e.g. `12.4 MB used`, `1.25 GB used`).
- **Unlatched**: shows current Wi-Fi SSID (e.g. `VIT-WiFi`) or `Disconnected`.
- **Wi-Fi Disabled / Disconnected**: shows `Wi-Fi off` or `Wi-Fi disconnected`.
- **Connecting / Latching**: preserves Wi-Fi SSID context while latching.

### Verification
- `./gradlew assembleDebug testDebugUnitTest :app:lintDebug` (passed)
- `./gradlew :desktop:compileKotlinDesktop :core:desktopTest :cli:build` (passed)
- `./gradlew :desktop:smoke` (passed)