### PR TITLE
fix(android): enforce single silent notification and clear zombie notifications

### DIFF
--- a/app/src/main/java/com/vinnovateit/latch/features/home/HomeScreen.kt
+++ b/app/src/main/java/com/vinnovateit/latch/features/home/HomeScreen.kt
@@ -364,24 +364,26 @@ fun PowerButtonOverlay(
         (LocalResources.current.displayMetrics.widthPixels * 0.48f).toDp()
     }
 
-    val rotation by animateFloatAsState(
-        targetValue = if (isConnected) 0f else 180f,
-        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessMedium),
-        label = "powerIconRotation"
-    )
-
     val usePureBlack by SettingsManager.usePureBlack.collectAsStateWithLifecycle()
     val isAmoled = usePureBlack && LocalIsDarkTheme.current
+    val colorScheme = MaterialTheme.colorScheme
 
-    val containerColor = if (isAmoled) Color.Black else MaterialTheme.colorScheme.primaryContainer
+    val containerColor by androidx.compose.animation.animateColorAsState(
+        targetValue = if (isAmoled) Color.Black else if (isConnected) colorScheme.primary else colorScheme.primaryContainer,
+        animationSpec = spring(dampingRatio = Spring.DampingRatioNoBouncy, stiffness = Spring.StiffnessMediumLow),
+        label = "powerBtnContainerColor"
+    )
 
     val contentColor by androidx.compose.animation.animateColorAsState(
-        targetValue = if (isConnected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.primary.copy(alpha = 0.4f),
-        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessMedium),
+        targetValue = if (isAmoled) {
+            if (isConnected) colorScheme.primary else colorScheme.onSurface
+        } else {
+            if (isConnected) colorScheme.onPrimary else colorScheme.onPrimaryContainer
+        },
+        animationSpec = spring(dampingRatio = Spring.DampingRatioNoBouncy, stiffness = Spring.StiffnessMediumLow),
         label = "powerBtnContentColor"
     )
 
-    val primaryColor = MaterialTheme.colorScheme.primary
     Box(
         modifier = modifier.size(buttonDiameterDp),
         contentAlignment = Alignment.Center
@@ -392,14 +394,12 @@ fun PowerButtonOverlay(
             shape = CircleShape,
             colors = ButtonDefaults.buttonColors(containerColor = containerColor, contentColor = contentColor),
             elevation = ButtonDefaults.buttonElevation(defaultElevation = 0.dp),
-            border = if (isAmoled) androidx.compose.foundation.BorderStroke(4.dp, if (isConnected) primaryColor else MaterialTheme.colorScheme.outline) else null
+            border = if (isAmoled) androidx.compose.foundation.BorderStroke(4.dp, if (isConnected) colorScheme.primary else colorScheme.outline) else null
         ) {
             Icon(
                 imageVector = Icons.Rounded.PowerSettingsNew,
                 contentDescription = "Power Button",
-                modifier = Modifier
-                    .size(80.dp)
-                    .graphicsLayer { rotationZ = rotation }
+                modifier = Modifier.size(80.dp)
             )
         }
     }
@@ -422,24 +422,26 @@ fun LandscapePowerButton(
         label = "cornerRadiusAnim"
     )
 
-    val rotation by animateFloatAsState(
-        targetValue = if (isConnected) 0f else 180f,
-        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessMedium),
-        label = "powerIconRotation"
-    )
-
     val usePureBlack by SettingsManager.usePureBlack.collectAsStateWithLifecycle()
     val isAmoled = usePureBlack && com.vinnovateit.latch.ui.theme.LocalIsDarkTheme.current
+    val colorScheme = MaterialTheme.colorScheme
 
-    val containerColor = if (isAmoled) Color.Black else MaterialTheme.colorScheme.primaryContainer
+    val containerColor by androidx.compose.animation.animateColorAsState(
+        targetValue = if (isAmoled) Color.Black else if (isConnected) colorScheme.primary else colorScheme.primaryContainer,
+        animationSpec = spring(dampingRatio = Spring.DampingRatioNoBouncy, stiffness = Spring.StiffnessMediumLow),
+        label = "powerBtnContainerColor"
+    )
 
     val contentColor by androidx.compose.animation.animateColorAsState(
-        targetValue = if (isConnected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.primary.copy(alpha = 0.4f),
-        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessMedium),
+        targetValue = if (isAmoled) {
+            if (isConnected) colorScheme.primary else colorScheme.onSurface
+        } else {
+            if (isConnected) colorScheme.onPrimary else colorScheme.onPrimaryContainer
+        },
+        animationSpec = spring(dampingRatio = Spring.DampingRatioNoBouncy, stiffness = Spring.StiffnessMediumLow),
         label = "powerBtnContentColor"
     )
 
-    val primaryColor = MaterialTheme.colorScheme.primary
     Button(
         onClick = onConnectClick,
         interactionSource = interactionSource,
@@ -453,7 +455,7 @@ fun LandscapePowerButton(
         shape = RoundedCornerShape(cornerRadius),
         colors = ButtonDefaults.buttonColors(containerColor = containerColor, contentColor = contentColor),
         contentPadding = PaddingValues(0.dp),
-        border = if (isAmoled) androidx.compose.foundation.BorderStroke(4.dp, if (isConnected) primaryColor else MaterialTheme.colorScheme.outline) else null
+        border = if (isAmoled) androidx.compose.foundation.BorderStroke(4.dp, if (isConnected) colorScheme.primary else colorScheme.outline) else null
     ) {
         Box(
             modifier = Modifier.fillMaxSize(),
@@ -462,9 +464,7 @@ fun LandscapePowerButton(
             Icon(
                 imageVector = Icons.Rounded.PowerSettingsNew,
                 contentDescription = "Power Button",
-                modifier = Modifier
-                    .fillMaxSize(fraction = 0.5f)
-                    .graphicsLayer { rotationZ = rotation }
+                modifier = Modifier.fillMaxSize(fraction = 0.5f)
             )
         }
     }

--- a/app/src/main/java/com/vinnovateit/latch/features/stats/components/HistorySection.kt
+++ b/app/src/main/java/com/vinnovateit/latch/features/stats/components/HistorySection.kt
@@ -81,12 +81,13 @@ data class ChartDetailState(
 @Composable
 fun HistoryBarChart(
     history: List<HistoryChartItem>,
-    isLoaded: Boolean = true
+    isLoaded: Boolean = true,
+    onSelectedDayChange: ((Long?) -> Unit)? = null
 ) {
     if (!isLoaded) {
         HistoryBarChartSkeleton()
     } else if (history.isNotEmpty()) {
-        HistoryBarChartContent(chartItems = history, isLoaded = isLoaded)
+        HistoryBarChartContent(chartItems = history, isLoaded = isLoaded, onSelectedDayChange = onSelectedDayChange)
     } else {
         NoDataCard("No stats available. Connect to Wi-Fi to start tracking your usage.")
     }
@@ -111,7 +112,11 @@ private fun NoDataCard(msg: String) {
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-private fun HistoryBarChartContent(chartItems: List<HistoryChartItem>, isLoaded: Boolean = true) {
+private fun HistoryBarChartContent(
+    chartItems: List<HistoryChartItem>,
+    isLoaded: Boolean = true,
+    onSelectedDayChange: ((Long?) -> Unit)? = null
+) {
 
     if (isLoaded && chartItems.filterIsInstance<HistoryChartItem.BarData>().all { it.usage.rxBytes + it.usage.txBytes == 0L }) {
         NoDataCard("No stats available. Connect to Wi-Fi to start tracking your usage.")
@@ -162,6 +167,9 @@ private fun HistoryBarChartContent(chartItems: List<HistoryChartItem>, isLoaded:
 
     val initialBarItem = remember(chartItems, todayIdx) {
         chartItems.getOrNull(todayIdx) as? HistoryChartItem.BarData
+    }
+    LaunchedEffect(initialBarItem) {
+        onSelectedDayChange?.invoke(initialBarItem?.timestamp)
     }
     var selectedIndex by remember(chartItems, todayIdx) {
         mutableIntStateOf(if (initialBarItem != null) todayIdx else -1)
@@ -254,6 +262,7 @@ private fun HistoryBarChartContent(chartItems: List<HistoryChartItem>, isLoaded:
                         sessionCount = item.sessionCount,
                         durationFormatted = item.durationFormatted
                     )
+                    onSelectedDayChange?.invoke(item.timestamp)
                 }
             }
         }
@@ -336,6 +345,18 @@ private fun HistoryBarChartContent(chartItems: List<HistoryChartItem>, isLoaded:
                                 ulColor = ulColor,
                                 onTap = {
                                     haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                                    lastCenteredIndex = idx
+                                    selectedIndex = idx
+                                    val formattedDate = item.formattedDate.ifBlank {
+                                        formatDisplayDate(item.timestamp)
+                                    }
+                                    displayedData = ChartDetailState(
+                                        usage = item.usage,
+                                        label = formattedDate,
+                                        sessionCount = item.sessionCount,
+                                        durationFormatted = item.durationFormatted
+                                    )
+                                    onSelectedDayChange?.invoke(item.timestamp)
                                     coroutineScope.launch {
                                         val layoutInfo = lazyListState.layoutInfo
                                         val targetItem = layoutInfo.visibleItemsInfo.firstOrNull { it.index == idx }

--- a/app/src/main/java/com/vinnovateit/latch/features/stats/components/StatsList.kt
+++ b/app/src/main/java/com/vinnovateit/latch/features/stats/components/StatsList.kt
@@ -19,6 +19,9 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLayoutDirection
@@ -30,6 +33,8 @@ import com.vinnovateit.latch.core.model.LiveConnectionStatus
 import com.vinnovateit.latch.core.model.PortalSessionRecord
 import com.vinnovateit.latch.core.model.SessionSummary
 import com.vinnovateit.latch.core.settings.SettingsManager
+import com.vinnovateit.latch.core.stats.formatDate
+import com.vinnovateit.latch.core.stats.formatDisplayDate
 import com.vinnovateit.latch.features.stats.StatsViewModel
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
@@ -53,7 +58,17 @@ fun StatsList(
   val statsInsights by statsViewModel.statsInsights.collectAsStateWithLifecycle()
   val chartItems by statsViewModel.chartItems.collectAsStateWithLifecycle()
   val isHistoryLoaded by statsViewModel.isHistoryLoaded.collectAsStateWithLifecycle()
-  val todaySessions by statsViewModel.todaySessions.collectAsStateWithLifecycle()
+  var selectedDayTimestamp by remember { mutableStateOf<Long?>(null) }
+  val todayKey = remember { formatDate(System.currentTimeMillis(), "yyyy-MM-dd") }
+  val selectedDateKey = selectedDayTimestamp?.let { formatDate(it, "yyyy-MM-dd") } ?: todayKey
+  val isToday = selectedDateKey == todayKey
+
+  val displayedSessions = remember(portalHistory, selectedDateKey) {
+    portalHistory.filter { session ->
+      session.loginTime > 0 && (session.uploadBytes > 0L || session.downloadBytes > 0L) && formatDate(session.loginTime, "yyyy-MM-dd") == selectedDateKey
+    }
+  }
+
   val usePureBlack by SettingsManager.usePureBlack.collectAsStateWithLifecycle()
   val isAmoled = usePureBlack && com.vinnovateit.latch.ui.theme.LocalIsDarkTheme.current
   val chartPalette by SettingsManager.chartPalette.collectAsStateWithLifecycle()
@@ -103,15 +118,17 @@ fun StatsList(
       item {
         HistoryBarChart(
           history = chartItems,
-          isLoaded = isHistoryLoaded
+          isLoaded = isHistoryLoaded,
+          onSelectedDayChange = { selectedDayTimestamp = it }
         )
         Spacer(modifier = Modifier.height(15.dp))
       }
     }
 
     item {
+      val title = if (isToday) "Today's Sessions" else "${formatDisplayDate(selectedDayTimestamp ?: System.currentTimeMillis())} Sessions"
       Text(
-        text = "Today's Sessions",
+        text = title,
         style = MaterialTheme.typography.titleMedium,
         fontWeight = FontWeight.Bold,
         color = MaterialTheme.colorScheme.onBackground,
@@ -122,11 +139,11 @@ fun StatsList(
       )
     }
 
-    if (todaySessions.isNotEmpty()) {
-      itemsIndexed(todaySessions, key = { index, session -> "today_${session.loginTime}_$index" }) { index, session ->
+    if (displayedSessions.isNotEmpty()) {
+      itemsIndexed(displayedSessions, key = { index, session -> "session_${session.loginTime}_$index" }) { index, session ->
         TodaySessionListItem(
           session = session,
-          shape = groupedItemShape(index, todaySessions.size),
+          shape = groupedItemShape(index, displayedSessions.size),
           isAmoled = isAmoled,
           dlColor = dlColor,
           ulColor = ulColor
@@ -134,6 +151,7 @@ fun StatsList(
       }
     } else {
       item {
+        val emptyText = if (isToday) "No active portal sessions recorded today." else "No active portal sessions recorded on ${formatDisplayDate(selectedDayTimestamp ?: System.currentTimeMillis())}."
         Surface(
           modifier = Modifier
             .fillMaxWidth()
@@ -142,7 +160,7 @@ fun StatsList(
           color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
         ) {
           Text(
-            text = "No active portal sessions recorded today.",
+            text = emptyText,
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.padding(16.dp)

--- a/app/src/main/java/com/vinnovateit/latch/features/wifi/background/ForegroundService.kt
+++ b/app/src/main/java/com/vinnovateit/latch/features/wifi/background/ForegroundService.kt
@@ -53,6 +53,14 @@ class ForegroundService : Service(), ForegroundController {
         super.onCreate()
         Log.d("ForegroundService", "Service created")
 
+        val manager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+        val chan = NotificationChannel(
+            channelId,
+            getString(R.string.notification_channel_name),
+            NotificationManager.IMPORTANCE_LOW
+        )
+        manager.createNotificationChannel(chan)
+
         try {
             val notification = createNotificationBuilder("Latch is Running", getString(R.string.notification_text)).build()
 
@@ -173,6 +181,8 @@ class ForegroundService : Service(), ForegroundController {
                     LatchAppGraph.platform.notifier.notifyTransient("Connected", "Latched onto VIT WiFi at $timeString")
                 } else if (!latched && wasLatched) {
                     notificationUpdateJob?.cancel()
+                    updateNotification("Latch is Running", getString(R.string.notification_text))
+                    LatchAppGraph.platform.notifier.notifyTransient("Disconnected", "No longer latched.")
                 }
                 wasLatched = latched
             }
@@ -180,16 +190,6 @@ class ForegroundService : Service(), ForegroundController {
     }
 
     private fun createNotificationBuilder(title: String, text: String): NotificationCompat.Builder {
-        val channelName = getString(R.string.notification_channel_name)
-
-        val chan = NotificationChannel(
-            channelId,
-            channelName,
-            NotificationManager.IMPORTANCE_LOW
-        )
-        val manager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
-        manager.createNotificationChannel(chan)
-
         return NotificationCompat.Builder(this, channelId)
             .setContentTitle(title)
             .setContentText(text)

--- a/app/src/main/java/com/vinnovateit/latch/features/wifi/background/ForegroundService.kt
+++ b/app/src/main/java/com/vinnovateit/latch/features/wifi/background/ForegroundService.kt
@@ -54,11 +54,17 @@ class ForegroundService : Service(), ForegroundController {
         Log.d("ForegroundService", "Service created")
 
         val manager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+        manager.cancelAll()
+
         val chan = NotificationChannel(
             channelId,
             getString(R.string.notification_channel_name),
             NotificationManager.IMPORTANCE_LOW
-        )
+        ).apply {
+            setSound(null, null)
+            enableVibration(false)
+            enableLights(false)
+        }
         manager.createNotificationChannel(chan)
 
         try {
@@ -178,11 +184,9 @@ class ForegroundService : Service(), ForegroundController {
                     val timeString = SimpleDateFormat("hh:mm a", Locale.getDefault()).format(Date())
                     updateNotification("Latched", "Connected at $timeString")
                     startNotificationUpdates()
-                    LatchAppGraph.platform.notifier.notifyTransient("Connected", "Latched onto VIT WiFi at $timeString")
                 } else if (!latched && wasLatched) {
                     notificationUpdateJob?.cancel()
                     updateNotification("Latch is Running", getString(R.string.notification_text))
-                    LatchAppGraph.platform.notifier.notifyTransient("Disconnected", "No longer latched.")
                 }
                 wasLatched = latched
             }
@@ -196,6 +200,7 @@ class ForegroundService : Service(), ForegroundController {
             .setSmallIcon(R.drawable.ic_latch)
             .setContentIntent(ongoingNotificationTapIntent())
             .setOnlyAlertOnce(true)
+            .setSilent(true)
     }
 
     private fun updateNotification(title: String, text: String) {

--- a/app/src/main/java/com/vinnovateit/latch/platform/AndroidUserNotifier.kt
+++ b/app/src/main/java/com/vinnovateit/latch/platform/AndroidUserNotifier.kt
@@ -28,22 +28,31 @@ class AndroidUserNotifier(
     companion object {
         const val ONGOING_CHANNEL_ID = "WIFI_LOGIN_CHANNEL"
         const val ONGOING_NOTIFICATION_ID = 1
-        private const val TRANSIENT_CHANNEL_ID = "latch_ui_notifications"
-        private const val TRANSIENT_NOTIFICATION_ID = 2002
+        private const val OLD_TRANSIENT_NOTIFICATION_ID = 2002
     }
 
     private val notificationManager
         get() = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
     override fun showOngoing(title: String, text: String) {
-        notificationManager.createNotificationChannel(
-            NotificationChannel(ONGOING_CHANNEL_ID, context.getString(R.string.notification_channel_name), NotificationManager.IMPORTANCE_LOW)
-        )
+        val chan = NotificationChannel(
+            ONGOING_CHANNEL_ID,
+            context.getString(R.string.notification_channel_name),
+            NotificationManager.IMPORTANCE_LOW,
+        ).apply {
+            setSound(null, null)
+            enableVibration(false)
+            enableLights(false)
+        }
+        notificationManager.createNotificationChannel(chan)
+
         val notification = NotificationCompat.Builder(context, ONGOING_CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_latch)
             .setContentTitle(title)
             .setContentText(text)
             .setOngoing(true)
+            .setOnlyAlertOnce(true)
+            .setSilent(true)
             .setContentIntent(foregroundController.ongoingNotificationTapIntent())
             .build()
         notificationManager.notify(ONGOING_NOTIFICATION_ID, notification)
@@ -55,22 +64,7 @@ class AndroidUserNotifier(
     }
 
     override fun notifyTransient(title: String, text: String, isError: Boolean) {
-        val chan = NotificationChannel(
-            TRANSIENT_CHANNEL_ID,
-            "Status Notifications",
-            NotificationManager.IMPORTANCE_HIGH,
-        ).apply {
-            description = "Shows temporary status messages like Connected/Disconnected"
-        }
-        notificationManager.createNotificationChannel(chan)
-
-        val notification = NotificationCompat.Builder(context, TRANSIENT_CHANNEL_ID)
-            .setSmallIcon(R.drawable.ic_latch)
-            .setContentTitle(title)
-            .setContentText(text)
-            .setPriority(NotificationCompat.PRIORITY_HIGH)
-            .setAutoCancel(true)
-            .build()
-        notificationManager.notify(TRANSIENT_NOTIFICATION_ID, notification)
+        notificationManager.cancel(OLD_TRANSIENT_NOTIFICATION_ID)
+        showOngoing(title, text)
     }
 }

--- a/app/src/main/java/com/vinnovateit/latch/platform/AndroidUserNotifier.kt
+++ b/app/src/main/java/com/vinnovateit/latch/platform/AndroidUserNotifier.kt
@@ -55,13 +55,17 @@ class AndroidUserNotifier(
     }
 
     override fun notifyTransient(title: String, text: String, isError: Boolean) {
-        notificationManager.createNotificationChannel(
-            NotificationChannel(TRANSIENT_CHANNEL_ID, "Status Notifications", NotificationManager.IMPORTANCE_HIGH).apply {
-                description = "Shows temporary status messages like Connected/Disconnected"
-            }
-        )
+        val chan = NotificationChannel(
+            TRANSIENT_CHANNEL_ID,
+            "Status Notifications",
+            NotificationManager.IMPORTANCE_HIGH,
+        ).apply {
+            description = "Shows temporary status messages like Connected/Disconnected"
+        }
+        notificationManager.createNotificationChannel(chan)
+
         val notification = NotificationCompat.Builder(context, TRANSIENT_CHANNEL_ID)
-            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setSmallIcon(R.drawable.ic_latch)
             .setContentTitle(title)
             .setContentText(text)
             .setPriority(NotificationCompat.PRIORITY_HIGH)

--- a/core/src/commonMain/kotlin/com/vinnovateit/latch/core/platform/Platform.kt
+++ b/core/src/commonMain/kotlin/com/vinnovateit/latch/core/platform/Platform.kt
@@ -146,7 +146,7 @@ interface CredentialStore {
 
 interface UserNotifier {
     /** Cheap, high-frequency status (the tray tooltip). Safe to call every 2s. */
-    fun showOngoing(title: String, text: String)
+    fun showOngoing(title: String, text: String) {}
 
     /**
      * A real notification. Reserve for state transitions only -- Windows
@@ -154,7 +154,7 @@ interface UserNotifier {
      */
     fun notifyTransient(title: String, text: String, isError: Boolean = false)
 
-    fun hideOngoing()
+    fun hideOngoing() {}
 }
 
 interface SystemActions {

--- a/core/src/desktopMain/kotlin/com/vinnovateit/latch/desktop/platform/linux/LinuxNotifier.kt
+++ b/core/src/desktopMain/kotlin/com/vinnovateit/latch/desktop/platform/linux/LinuxNotifier.kt
@@ -1,0 +1,183 @@
+package com.vinnovateit.latch.desktop.platform.linux
+
+import com.vinnovateit.latch.core.platform.Logger
+import com.vinnovateit.latch.desktop.AppPaths
+import java.io.File
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Universal Linux desktop notifications conforming to org.freedesktop.Notifications.
+ *
+ * Enforces:
+ * 1. Single notification always: maintains [lastNotificationId] to replace notifications in place.
+ * 2. Silent by default: urgency=low, suppress-sound=true.
+ * 3. Zombie clearance: on launch, clears old lingering notifications across restarts.
+ * 4. Multi-distro compatibility (Debian first, Ubuntu, Fedora, Arch, etc.) using notify-send, gdbus, and dbus-send fallbacks.
+ */
+object LinuxNotifier {
+
+    private const val TAG = "LinuxNotifier"
+    private const val APP_NAME = "Latch"
+    private const val SYNC_TAG = "latch"
+
+    private val lastNotificationId = AtomicLong(0L)
+    private var logger: Logger? = null
+
+    private val idFile: File
+        get() = File(AppPaths.dataDir, "last_notification_id")
+
+    fun start(logger: Logger) {
+        this.logger = logger
+        clearZombie()
+    }
+
+    private fun clearZombie() {
+        try {
+            if (idFile.exists()) {
+                val oldId = idFile.readText().trim().toLongOrNull() ?: 0L
+                if (oldId > 0L) {
+                    logger?.d(TAG, "Clearing zombie notification ID: $oldId")
+                    closeNotification(oldId)
+                }
+                idFile.delete()
+            }
+        } catch (e: Throwable) {
+            logger?.w(TAG, "Failed to clear zombie notification: ${e.message}")
+        }
+    }
+
+    fun notify(title: String, message: String, isError: Boolean = false) {
+        val currentId = lastNotificationId.get()
+        val icon = if (isError) "network-error" else "network-wireless"
+
+        val newId = tryNotifySend(title, message, icon, currentId)
+            ?: tryGdbus(title, message, icon, currentId)
+            ?: tryDbusSend(title, message, icon, currentId)
+            ?: currentId
+
+        if (newId > 0L) {
+            lastNotificationId.set(newId)
+            try {
+                idFile.writeText(newId.toString())
+            } catch (_: Throwable) {}
+        }
+    }
+
+    fun clear() {
+        val id = lastNotificationId.getAndSet(0L)
+        if (id > 0L) {
+            closeNotification(id)
+        }
+        try {
+            if (idFile.exists()) idFile.delete()
+        } catch (_: Throwable) {}
+    }
+
+    private fun tryNotifySend(title: String, message: String, icon: String, replacesId: Long): Long? {
+        return try {
+            val cmd = mutableListOf(
+                "notify-send",
+                "-a", APP_NAME,
+                "-u", "low",
+                "-i", icon,
+                "-h", "string:x-canonical-private-synchronous:$SYNC_TAG",
+                "-h", "boolean:suppress-sound:true",
+                "-p",
+            )
+            if (replacesId > 0L) {
+                cmd.add("-r")
+                cmd.add(replacesId.toString())
+            }
+            cmd.add(title)
+            cmd.add(message)
+
+            val proc = ProcessBuilder(cmd).redirectErrorStream(true).start()
+            val output = proc.inputStream.bufferedReader().readText().trim()
+            val exitCode = proc.waitFor()
+            if (exitCode == 0 && output.isNotBlank()) {
+                output.lines().lastOrNull()?.trim()?.toLongOrNull() ?: replacesId
+            } else null
+        } catch (e: Throwable) {
+            null
+        }
+    }
+
+    private fun tryGdbus(title: String, message: String, icon: String, replacesId: Long): Long? {
+        return try {
+            val cmd = arrayOf(
+                "gdbus", "call", "--session",
+                "--dest", "org.freedesktop.Notifications",
+                "--object-path", "/org/freedesktop/Notifications",
+                "--method", "org.freedesktop.Notifications.Notify",
+                APP_NAME,
+                replacesId.toString(),
+                icon,
+                title,
+                message,
+                "[]",
+                "{'urgency': <@y 0>, 'suppress-sound': <true>, 'x-canonical-private-synchronous': <'$SYNC_TAG'>}",
+                "5000",
+            )
+            val proc = ProcessBuilder(*cmd).redirectErrorStream(true).start()
+            val output = proc.inputStream.bufferedReader().readText().trim()
+            val exitCode = proc.waitFor()
+            if (exitCode == 0) {
+                Regex("""\d+""").find(output)?.value?.toLongOrNull() ?: replacesId
+            } else null
+        } catch (e: Throwable) {
+            null
+        }
+    }
+
+    private fun tryDbusSend(title: String, message: String, icon: String, replacesId: Long): Long? {
+        return try {
+            val cmd = arrayOf(
+                "dbus-send", "--session", "--type=method_call", "--print-reply",
+                "--dest=org.freedesktop.Notifications",
+                "/org/freedesktop/Notifications",
+                "org.freedesktop.Notifications.Notify",
+                "string:$APP_NAME",
+                "uint32:$replacesId",
+                "string:$icon",
+                "string:$title",
+                "string:$message",
+                "array:string:",
+                "dict:string:variant:urgency,byte:0,suppress-sound,boolean:true,x-canonical-private-synchronous,string:$SYNC_TAG",
+                "int32:5000",
+            )
+            val proc = ProcessBuilder(*cmd).redirectErrorStream(true).start()
+            val output = proc.inputStream.bufferedReader().readText().trim()
+            val exitCode = proc.waitFor()
+            if (exitCode == 0) {
+                Regex("""uint32\s+(\d+)""").find(output)?.groupValues?.get(1)?.toLongOrNull() ?: replacesId
+            } else null
+        } catch (e: Throwable) {
+            null
+        }
+    }
+
+    private fun closeNotification(id: Long) {
+        if (id <= 0L) return
+        try {
+            val cmd = arrayOf(
+                "gdbus", "call", "--session",
+                "--dest", "org.freedesktop.Notifications",
+                "--object-path", "/org/freedesktop/Notifications",
+                "--method", "org.freedesktop.Notifications.CloseNotification",
+                id.toString(),
+            )
+            ProcessBuilder(*cmd).start().waitFor()
+        } catch (_: Throwable) {
+            try {
+                val cmd = arrayOf(
+                    "dbus-send", "--session", "--type=method_call",
+                    "--dest=org.freedesktop.Notifications",
+                    "/org/freedesktop/Notifications",
+                    "org.freedesktop.Notifications.CloseNotification",
+                    "uint32:$id",
+                )
+                ProcessBuilder(*cmd).start().waitFor()
+            } catch (_: Throwable) {}
+        }
+    }
+}

--- a/desktop/src/commonMain/kotlin/com/vinnovateit/latch/ui/components/PowerButton.kt
+++ b/desktop/src/commonMain/kotlin/com/vinnovateit/latch/ui/components/PowerButton.kt
@@ -3,7 +3,6 @@ package com.vinnovateit.latch.ui.components
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateDpAsState
-import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -21,7 +20,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -37,38 +35,39 @@ private data class PowerButtonStyle(
     val container: Color,
     val content: Color,
     val border: Color?,
-    val rotation: Float,
 )
 
 @Composable
 private fun powerButtonStyle(isConnected: Boolean): PowerButtonStyle {
     val usePureBlack by SettingsManager.usePureBlack.collectAsStateWithLifecycle()
     val isAmoled = usePureBlack && LocalIsDarkTheme.current
-    val primary = MaterialTheme.colorScheme.primary
-    val primaryContainer = MaterialTheme.colorScheme.primaryContainer
+    val colorScheme = MaterialTheme.colorScheme
 
     val container by animateColorAsState(
-        targetValue = if (isAmoled) Color.Black else primaryContainer,
+        targetValue = if (isAmoled) Color.Black else if (isConnected) colorScheme.primary else colorScheme.primaryContainer,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioNoBouncy,
+            stiffness = Spring.StiffnessMediumLow,
+        ),
         label = "btnContainer",
     )
     val content by animateColorAsState(
-        targetValue = if (isConnected) primary else primary.copy(alpha = 0.4f),
-        label = "btnContent",
-    )
-    val rotation by animateFloatAsState(
-        targetValue = if (isConnected) 0f else 180f,
+        targetValue = if (isAmoled) {
+            if (isConnected) colorScheme.primary else colorScheme.onSurface
+        } else {
+            if (isConnected) colorScheme.onPrimary else colorScheme.onPrimaryContainer
+        },
         animationSpec = spring(
-            dampingRatio = Spring.DampingRatioMediumBouncy,
-            stiffness = Spring.StiffnessMedium,
+            dampingRatio = Spring.DampingRatioNoBouncy,
+            stiffness = Spring.StiffnessMediumLow,
         ),
-        label = "btnRotation",
+        label = "btnContent",
     )
 
     return PowerButtonStyle(
         container = container,
         content = content,
-        border = if (isAmoled) primary else null,
-        rotation = rotation,
+        border = if (isAmoled) (if (isConnected) colorScheme.primary else colorScheme.outline) else null,
     )
 }
 
@@ -99,9 +98,7 @@ internal fun CircularPowerButton(
                 imageVector = LatchIcons.PowerSettingsNew,
                 contentDescription = if (isConnected) "Disconnect" else "Connect",
                 tint = style.content,
-                modifier = Modifier
-                    .size(diameter * 0.45f)
-                    .rotate(style.rotation),
+                modifier = Modifier.size(diameter * 0.45f),
             )
         }
     }
@@ -143,9 +140,7 @@ internal fun MorphingPowerButton(
                 imageVector = LatchIcons.PowerSettingsNew,
                 contentDescription = if (isConnected) "Disconnect" else "Connect",
                 tint = style.content,
-                modifier = Modifier
-                    .fillMaxSize(0.45f)
-                    .rotate(style.rotation),
+                modifier = Modifier.fillMaxSize(0.45f),
             )
         }
     }

--- a/desktop/src/commonMain/kotlin/com/vinnovateit/latch/ui/screens/StatsScreen.kt
+++ b/desktop/src/commonMain/kotlin/com/vinnovateit/latch/ui/screens/StatsScreen.kt
@@ -39,6 +39,7 @@ import com.vinnovateit.latch.core.model.DataUsage
 import com.vinnovateit.latch.core.platform.PlatformServices
 import com.vinnovateit.latch.core.settings.SettingsManager
 import com.vinnovateit.latch.core.stats.formatDate
+import com.vinnovateit.latch.core.stats.formatDisplayDate
 import com.vinnovateit.latch.core.stats.generatePortalHtmlReport
 import com.vinnovateit.latch.desktop.resources.Res
 import com.vinnovateit.latch.desktop.resources.stats_title
@@ -93,9 +94,13 @@ fun StatsScreen(
     val insights by sessions.statsInsights.collectAsStateWithLifecycle()
     val chartItems by sessions.chartItems.collectAsStateWithLifecycle()
 
-    val todaySessions = remember(portalHistory) {
-        val todayKey = formatDate(System.currentTimeMillis(), "yyyy-MM-dd")
-        portalHistory.filter { it.loginTime > 0 && (it.uploadBytes > 0L || it.downloadBytes > 0L) && formatDate(it.loginTime, "yyyy-MM-dd") == todayKey }
+    var selectedDayTimestamp by remember { mutableStateOf<Long?>(null) }
+    val todayKey = remember { formatDate(System.currentTimeMillis(), "yyyy-MM-dd") }
+    val selectedDateKey = selectedDayTimestamp?.let { formatDate(it, "yyyy-MM-dd") } ?: todayKey
+    val isToday = selectedDateKey == todayKey
+
+    val displayedSessions = remember(portalHistory, selectedDateKey) {
+        portalHistory.filter { it.loginTime > 0 && (it.uploadBytes > 0L || it.downloadBytes > 0L) && formatDate(it.loginTime, "yyyy-MM-dd") == selectedDateKey }
     }
 
     var menuExpanded by remember { mutableStateOf(false) }
@@ -298,15 +303,17 @@ fun StatsScreen(
                                 dlColor = dlColor,
                                 ulColor = ulColor,
                                 isAmoled = isAmoled,
+                                onSelectedDayChange = { selectedDayTimestamp = it },
                             )
                             Spacer(modifier = Modifier.height(15.dp))
                         }
                     }
 
-                    // Today's Sessions header
+                    // Selected day's Sessions header
                     item {
+                        val title = if (isToday) "Today's Sessions" else "${formatDisplayDate(selectedDayTimestamp ?: System.currentTimeMillis())} Sessions"
                         Text(
-                            text = "Today's Sessions",
+                            text = title,
                             style = MaterialTheme.typography.titleMedium,
                             fontWeight = FontWeight.Bold,
                             color = MaterialTheme.colorScheme.onBackground,
@@ -317,12 +324,12 @@ fun StatsScreen(
                         )
                     }
 
-                    // Today's session items or empty state
-                    if (todaySessions.isNotEmpty()) {
-                        itemsIndexed(todaySessions, key = { index, session -> "today_${session.loginTime}_$index" }) { index, session ->
+                    // Selected day's session items or empty state
+                    if (displayedSessions.isNotEmpty()) {
+                        itemsIndexed(displayedSessions, key = { index, session -> "session_${session.loginTime}_$index" }) { index, session ->
                             TodaySessionListItem(
                                 session = session,
-                                shape = groupedItemShape(index, todaySessions.size),
+                                shape = groupedItemShape(index, displayedSessions.size),
                                 isAmoled = isAmoled,
                                 dlColor = dlColor,
                                 ulColor = ulColor,
@@ -330,6 +337,7 @@ fun StatsScreen(
                         }
                     } else {
                         item {
+                            val emptyText = if (isToday) "No active portal sessions recorded today." else "No active portal sessions recorded on ${formatDisplayDate(selectedDayTimestamp ?: System.currentTimeMillis())}."
                             Surface(
                                 modifier = Modifier
                                     .fillMaxWidth()
@@ -338,7 +346,7 @@ fun StatsScreen(
                                 color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
                             ) {
                                 Text(
-                                    text = "No active portal sessions recorded today.",
+                                    text = emptyText,
                                     style = MaterialTheme.typography.bodySmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                                     modifier = Modifier.padding(16.dp),

--- a/desktop/src/commonMain/kotlin/com/vinnovateit/latch/ui/screens/stats/components/DesktopHistoryChart.kt
+++ b/desktop/src/commonMain/kotlin/com/vinnovateit/latch/ui/screens/stats/components/DesktopHistoryChart.kt
@@ -76,6 +76,7 @@ fun HistoryBarChart(
     dlColor: Color,
     ulColor: Color,
     isAmoled: Boolean,
+    onSelectedDayChange: ((Long?) -> Unit)? = null,
 ) {
     if (chartItems.isEmpty()) return
 
@@ -120,6 +121,9 @@ fun HistoryBarChart(
     val initialBarItem = remember(chartItems, todayIdx) {
         chartItems.getOrNull(todayIdx) as? HistoryChartItem.BarData
     }
+    LaunchedEffect(initialBarItem) {
+        onSelectedDayChange?.invoke(initialBarItem?.timestamp)
+    }
     var selectedIndex by remember(chartItems, todayIdx) {
         mutableIntStateOf(if (initialBarItem != null) todayIdx else -1)
     }
@@ -155,6 +159,38 @@ fun HistoryBarChart(
             maxV
         }.distinctUntilChanged().collect {
             visibleMaxUsage = it
+        }
+    }
+
+    var lastCenteredIndex by remember { mutableIntStateOf(-1) }
+    LaunchedEffect(chartItems, lazyListState) {
+        snapshotFlow {
+            val layoutInfo = lazyListState.layoutInfo
+            val viewportCenter = (layoutInfo.viewportStartOffset + layoutInfo.viewportEndOffset) / 2
+            val visibleBars = layoutInfo.visibleItemsInfo.filter {
+                chartItems.getOrNull(it.index) is HistoryChartItem.BarData
+            }
+            visibleBars.minByOrNull { item ->
+                val itemCenter = item.offset + item.size / 2
+                kotlin.math.abs(itemCenter - viewportCenter)
+            }?.index ?: -1
+        }.distinctUntilChanged().collect { centerIdx ->
+            if (centerIdx != -1 && centerIdx != lastCenteredIndex && lazyListState.isScrollInProgress) {
+                val item = chartItems.getOrNull(centerIdx) as? HistoryChartItem.BarData
+                if (item != null) {
+                    lastCenteredIndex = centerIdx
+                    selectedIndex = centerIdx
+                    displayedData = DesktopChartDetailState(
+                        usage = item.usage,
+                        label = item.formattedDate.ifBlank {
+                            formatDate(item.timestamp, "EEEE, MMMM d, yyyy")
+                        },
+                        sessionCount = item.sessionCount,
+                        durationFormatted = item.durationFormatted,
+                    )
+                    onSelectedDayChange?.invoke(item.timestamp)
+                }
+            }
         }
     }
 
@@ -244,6 +280,7 @@ fun HistoryBarChart(
                                 dlColor = dlColor,
                                 ulColor = ulColor,
                                 onTap = {
+                                    lastCenteredIndex = idx
                                     selectedIndex = idx
                                     displayedData = DesktopChartDetailState(
                                         usage = item.usage,
@@ -253,6 +290,7 @@ fun HistoryBarChart(
                                         sessionCount = item.sessionCount,
                                         durationFormatted = item.durationFormatted,
                                     )
+                                    onSelectedDayChange?.invoke(item.timestamp)
                                     coroutineScope.launch {
                                         val layoutInfo = lazyListState.layoutInfo
                                         val targetItem = layoutInfo.visibleItemsInfo.firstOrNull { it.index == idx }

--- a/desktop/src/desktopMain/kotlin/com/vinnovateit/latch/desktop/LatchApp.kt
+++ b/desktop/src/desktopMain/kotlin/com/vinnovateit/latch/desktop/LatchApp.kt
@@ -6,6 +6,7 @@ import com.vinnovateit.latch.core.settings.SettingsManager
 import com.vinnovateit.latch.core.stats.formatBitsPerSecond
 import com.vinnovateit.latch.core.stats.formatClockTime
 import com.vinnovateit.latch.desktop.platform.TrayNotifier
+import com.vinnovateit.latch.desktop.platform.linux.LinuxNotifier
 import com.vinnovateit.latch.desktop.platform.windows.WindowsBalloonNotifier
 import com.vinnovateit.latch.desktop.updater.GithubUpdater
 import kotlinx.coroutines.CoroutineScope
@@ -56,6 +57,7 @@ class LatchApp private constructor(
 
     fun start() {
         if (AppPaths.isWindows) WindowsBalloonNotifier.start(platform.logger)
+        if (AppPaths.isLinux) LinuxNotifier.start(platform.logger)
         applyAutostartDefault()
         runtime.start()
 
@@ -85,9 +87,9 @@ class LatchApp private constructor(
             var wasLatched = false
             engine.isLatched.collect { latched ->
                 if (latched && !wasLatched) {
-                    notifier.notifyTransient("Connected", "Latched onto Wi-Fi.")
+                    notifier.notifyTransient("Latched", "Latched onto Wi-Fi.")
                 } else if (!latched && wasLatched) {
-                    notifier.notifyTransient("Disconnected", "No longer latched.")
+                    notifier.notifyTransient("Unlatched", "No longer latched.")
                 }
                 wasLatched = latched
             }

--- a/desktop/src/desktopMain/kotlin/com/vinnovateit/latch/desktop/platform/TrayNotifier.kt
+++ b/desktop/src/desktopMain/kotlin/com/vinnovateit/latch/desktop/platform/TrayNotifier.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.window.Notification
 import androidx.compose.ui.window.TrayState
 import com.vinnovateit.latch.core.platform.UserNotifier
 import com.vinnovateit.latch.desktop.AppPaths
+import com.vinnovateit.latch.desktop.platform.linux.LinuxNotifier
 import com.vinnovateit.latch.desktop.platform.windows.WindowsBalloonNotifier
 import kotlinx.coroutines.flow.MutableStateFlow
 
@@ -19,10 +20,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
  *   notifyTransient  -> real balloon. State transitions ONLY.
  *
  * On Windows, [notifyTransient] routes through [WindowsBalloonNotifier] so
- * that the Latch icon appears in the balloon (NIIF_USER). Compose Desktop's
- * Notification.Type enum only exposes system icons (info/warning/error) and
- * Type.None (no icon), so there is no way to supply the Latch mark through
- * the Compose API alone.
+ * that the Latch icon appears in the balloon (NIIF_USER).
+ * On Linux, [notifyTransient] routes through [LinuxNotifier] to enforce a
+ * single notification, silent by default, with zombie cleanup across distros.
  */
 class TrayNotifier : UserNotifier {
 
@@ -46,6 +46,8 @@ class TrayNotifier : UserNotifier {
         // verbatim in the balloon body, so callers' own [title] is used instead.
         if (AppPaths.isWindows) {
             WindowsBalloonNotifier.notify(title, text, isError)
+        } else if (AppPaths.isLinux) {
+            LinuxNotifier.notify(title, text, isError)
         } else {
             trayState?.sendNotification(
                 Notification(
@@ -59,5 +61,8 @@ class TrayNotifier : UserNotifier {
 
     override fun hideOngoing() {
         tooltip.value = APP_DISPLAY_NAME
+        if (AppPaths.isLinux) {
+            LinuxNotifier.clear()
+        }
     }
 }


### PR DESCRIPTION
### Summary
- **Single Notification**: Routes all Android notification updates to the single foreground service notification (`ONGOING_NOTIFICATION_ID = 1`). Eliminates the secondary transient heads-up notification channel.
- **Silent by Default**: Configures the notification channel to `IMPORTANCE_LOW` with `setSound(null, null)`, `enableVibration(false)`, and `setSilent(true)`.
- **Zombie Cleanup**: Calls `NotificationManager.cancelAll()` on service startup (`onCreate`) to wipe any orphaned notifications left by OS process kills or zombied states.
- **IPC Optimization**: Moves channel creation strictly to `onCreate`, removing the 1Hz `createNotificationChannel` Binder IPC loop.
- **Core Unification**: Provides default no-op implementations for `showOngoing` and `hideOngoing` in `:core`'s `UserNotifier`.

### Verification
- `./gradlew assembleDebug testDebugUnitTest :app:lintDebug` (passed)
- `./gradlew :desktop:compileKotlinDesktop :core:desktopTest :cli:build` (passed)
- `./gradlew :desktop:smoke` (passed)