### PR TITLE
[Fix]: Repair Windows packaging and portal history race

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,7 +151,14 @@ jobs:
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force -Path staging | Out-Null
-          Copy-Item desktop\build\compose\binaries\main-release\msi\*.msi staging\
+          # Keep one stable GUI installer filename across patch rebuilds. The
+          # MSI's internal product/version metadata remains controlled by
+          # Compose/jpackage; only the release asset name is normalized here.
+          $msi = @(Get-ChildItem desktop\build\compose\binaries\main-release\msi\*.msi)
+          if ($msi.Count -ne 1) {
+            throw "Expected exactly one Desktop MSI, found $($msi.Count)"
+          }
+          Copy-Item $msi.FullName staging\Latch-Setup.msi
           Copy-Item cli\build\distributions\*.zip staging\
           Get-ChildItem staging
 

--- a/core/src/commonMain/kotlin/com/vinnovateit/latch/core/domain/SessionRepository.kt
+++ b/core/src/commonMain/kotlin/com/vinnovateit/latch/core/domain/SessionRepository.kt
@@ -140,7 +140,14 @@ class SessionRepository(
                     }
                 }
                 .collect { records ->
-                    _portalHistory.value = records
+                    // Room emits its initial snapshot asynchronously. If a manual
+                    // record is added before that empty snapshot arrives, do not
+                    // let the stale empty emission erase the in-memory record.
+                    // The insert flow will emit the authoritative non-empty row
+                    // shortly afterwards.
+                    if (records.isNotEmpty() || _portalHistory.value.isEmpty()) {
+                        _portalHistory.value = records
+                    }
                     _isHistoryLoaded.value = true
                 }
         }


### PR DESCRIPTION
Fixes the Windows Desktop release packaging and the flaky Linux portal reconciliation test.

- Normalize the Windows GUI asset to Latch-Setup.msi.
- Prevent Room's initial empty snapshot from erasing a newly recorded manual session.
- Both commits are signed.